### PR TITLE
Fallback earlier if D-Bus is not available

### DIFF
--- a/keychain_p.h
+++ b/keychain_p.h
@@ -68,7 +68,10 @@ public:
 #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
     org::kde::KWallet* iface;
     friend class QKeychain::JobExecutor;
+    void fallbackOnError(const QDBusError& err);
 
+    const QString typeKey();
+    const QString dataKey();
 private Q_SLOTS:
     void kwalletOpenFinished( QDBusPendingCallWatcher* watcher );
     void kwalletEntryTypeFinished( QDBusPendingCallWatcher* watcher );
@@ -102,7 +105,7 @@ public:
 #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
     org::kde::KWallet* iface;
     friend class QKeychain::JobExecutor;
-
+    void fallbackOnError(const QDBusError& err);
 
 private Q_SLOTS:
     void kwalletOpenFinished( QDBusPendingCallWatcher* watcher );


### PR DESCRIPTION
If D-Bus is not available, at the moment qtkeychain jobs do not return. I added the detection if D-Bus is running and moved the fallback code into an extra function to avoid code duplication as this code is now called from two locations.
