### PR TITLE
Query qmake5 for QT_TRANSLATION_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if(NOT QT_TRANSLATIONS_DIR)
     get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
     # Ask Qt5 where to put the translations
     EXEC_PROGRAM( ${QT5_QMAKE_EXECUTABLE}
-        ARGS "-query QT_INSTALL_TRANSLATIONS"
+        ARGS -query QT_INSTALL_TRANSLATIONS
         OUTPUT_VARIABLE qt_translations_dir )
     # make sure we have / and not \ as qmake gives on windows
     FILE(TO_CMAKE_PATH "${qt_translations_dir}" qt_translations_dir)


### PR DESCRIPTION
Ask qmake where the translation should be placed. This code snippet is based on the way CMake does it for Qt4. 
