### PR TITLE
Default to DesktopEnv_Other.

### DIFF
--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -79,6 +79,8 @@ static DesktopEnvironment detectDesktopEnvironment() {
             return DesktopEnv_Kde4;
         }
     }
+
+    return DesktopEnv_Other;
 }
 
 static KeyringBackend detectKeyringBackend()


### PR DESCRIPTION
Fixes:

```
qtkeychain/keychain_unix.cpp: In function ‘DesktopEnvironment detectDesktopEnvironment()’:
qtkeychain/keychain_unix.cpp:82:1: warning: control reaches end of non-void function [-Wreturn-type]
```

Weirdly this caused qtkeychain to ignore GnomeKeyring for me.
