### PR TITLE
avoid wchar types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ if (WIN32)
     option(USE_CREDENTIAL_STORE "Build with windows CredentialStore support" ON)
 
     if (USE_CREDENTIAL_STORE)
-	add_definitions(-DUSE_CREDENTIAL_STORE=1)
+       add_definitions(-DUSE_CREDENTIAL_STORE=1)
     endif()
+    add_definitions(-DUNICODE)
 endif()
 
 if( NOT BUILD_WITH_QT4 )
@@ -199,4 +200,3 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Qt${QTKEYCHAIN_VERSION_INFIX}KeychainC
               ${CMAKE_CURRENT_BINARY_DIR}/Qt${QTKEYCHAIN_VERSION_INFIX}KeychainConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Qt${QTKEYCHAIN_VERSION_INFIX}Keychain
 )
-

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -21,12 +21,12 @@ using namespace QKeychain;
 #include <wincred.h>
 
 void ReadPasswordJobPrivate::scheduledStart() {
-    std::wstring name = key.toStdWString();
+    std::string name = key.toStdString();
     //Use settings member if there, create local settings object if not
     std::auto_ptr<QSettings> local( !q->settings() ? new QSettings( q->service() ) : 0 );
     PCREDENTIALW cred;
 
-    if (!CredReadW(name.c_str(), CRED_TYPE_GENERIC, 0, &cred)) {
+    if (!CredReadW(reinterpret_cast<LPCWSTR>(name.c_str()), CRED_TYPE_GENERIC, 0, &cred)) {
         Error error;
         QString msg;
         switch(GetLastError()) {
@@ -53,7 +53,7 @@ void ReadPasswordJobPrivate::scheduledStart() {
 void WritePasswordJobPrivate::scheduledStart() {
     CREDENTIALW cred;
     char *pwd = data.data();
-    std::wstring name = key.toStdWString();
+    std::string name = key.toStdString();
 
     memset(&cred, 0, sizeof(cred));
     cred.Comment = L"QtKeychain";
@@ -71,9 +71,9 @@ void WritePasswordJobPrivate::scheduledStart() {
 }
 
 void DeletePasswordJobPrivate::scheduledStart() {
-    std::wstring name = key.toStdWString();
+    std::string name = key.toStdString();
 
-    if (!CredDeleteW(name.c_str(), CRED_TYPE_GENERIC, 0)) {
+    if (!CredDeleteW(reinterpret_cast<LPCWSTR>(name.c_str()), CRED_TYPE_GENERIC, 0)) {
         Error error;
         QString msg;
         switch(GetLastError()) {


### PR DESCRIPTION
fixes link problems with Qt versions built without proper wchar support

We don't want use wchar because Qt on Windows with MSVC can be built
optionally with or without /Zc:wchar_t. And we can't know which.
http://stackoverflow.com/questions/4521252/qt-msvc-and-zcwchar-t-i-want-to-blow-up-the-world