### PR TITLE
Fix gnome keyring binary / text mode password

### DIFF
--- a/gnomekeyring.cpp
+++ b/gnomekeyring.cpp
@@ -14,25 +14,39 @@ bool GnomeKeyring::isAvailable()
            keyring.is_available();
 }
 
-GnomeKeyring::gpointer GnomeKeyring::store_network_password( const gchar* keyring, const gchar* display_name,
-                                               const gchar* user, const gchar* server, const gchar* password,
-                                               OperationDoneCallback callback, gpointer data, GDestroyNotify destroy_data )
+GnomeKeyring::gpointer GnomeKeyring::store_network_password(
+        const gchar* keyring,
+        const gchar* display_name,
+        const gchar* user,
+        const gchar* server,
+        const gchar* type,
+        const gchar* password,
+        OperationDoneCallback callback,
+        gpointer data,
+        GDestroyNotify destroy_data )
 {
     if ( !isAvailable() )
         return 0;
     return instance().store_password( instance().NETWORK_PASSWORD,
-                                      keyring, display_name, password, callback, data, destroy_data,
-                                      "user", user, "server", server, static_cast<char*>(0) );
+                                      keyring, display_name, password, callback,
+                                      data, destroy_data,
+                                      "user", user,
+                                      "server", server,
+                                      "type", type,
+                                      static_cast<char*>(0) );
 }
 
-GnomeKeyring::gpointer GnomeKeyring::find_network_password( const gchar* user, const gchar* server,
-                                              OperationGetStringCallback callback, gpointer data, GDestroyNotify destroy_data )
+GnomeKeyring::gpointer GnomeKeyring::find_network_password(
+        const gchar* user, const gchar* server, const gchar* type,
+        OperationGetStringCallback callback, gpointer data, GDestroyNotify destroy_data )
 {
     if ( !isAvailable() )
         return 0;
+
     return instance().find_password( instance().NETWORK_PASSWORD,
                                      callback, data, destroy_data,
-                                     "user", user, "server", server, static_cast<char*>(0) );
+                                     "user", user, "server", server, "type", type,
+                                     static_cast<char*>(0) );
 }
 
 GnomeKeyring::gpointer GnomeKeyring::delete_network_password( const gchar* user,
@@ -55,6 +69,7 @@ GnomeKeyring::GnomeKeyring()
         ITEM_NETWORK_PASSWORD,
         {{ "user",   ATTRIBUTE_TYPE_STRING },
          { "server", ATTRIBUTE_TYPE_STRING },
+         { "type", ATTRIBUTE_TYPE_STRING },
          { 0,     static_cast<AttributeType>( 0 ) }}
     };
 

--- a/gnomekeyring_p.h
+++ b/gnomekeyring_p.h
@@ -43,7 +43,8 @@ public:
         } attributes[32];
     } PasswordSchema;
 
-    typedef void ( *OperationGetStringCallback )( Result result, const char* string, gpointer data );
+    typedef void ( *OperationGetStringCallback )( Result result, bool binary,
+                                                  const char* string, gpointer data );
     typedef void ( *OperationDoneCallback )( Result result, gpointer data );
     typedef void ( *GDestroyNotify )( gpointer data );
 
@@ -52,11 +53,14 @@ public:
     static bool isAvailable();
 
     static gpointer store_network_password( const gchar* keyring, const gchar* display_name,
-                                            const gchar* user, const gchar* server, const gchar* password,
+                                            const gchar* user, const gchar* server,
+                                            const gchar* type, const gchar* password,
                                             OperationDoneCallback callback, gpointer data, GDestroyNotify destroy_data );
 
     static gpointer find_network_password( const gchar* user, const gchar* server,
-                                           OperationGetStringCallback callback, gpointer data, GDestroyNotify destroy_data );
+                                           const gchar* type,
+                                           OperationGetStringCallback callback,
+                                           gpointer data, GDestroyNotify destroy_data );
 
     static gpointer delete_network_password( const gchar* user, const gchar* server,
                                              OperationDoneCallback callback, gpointer data, GDestroyNotify destroy_data );

--- a/testclient.cpp
+++ b/testclient.cpp
@@ -52,6 +52,29 @@ int main( int argc, char** argv ) {
             return 1;
         }
         std::cout << "Password stored successfully" << std::endl;
+    } else if ( *it == QLatin1String("bstore") ) {
+        if ( ++it == args.constEnd() )
+            return printUsage();
+        const QString acc = *it;
+        if ( ++it == args.constEnd() )
+            return printUsage();
+        const QString pass = *it;
+        if ( ++it != args.constEnd() )
+            return printUsage();
+        WritePasswordJob job( QLatin1String("qtkeychain-testclient") );
+        job.setAutoDelete( false );
+        job.setKey( acc );
+        job.setBinaryData( pass.toUtf8() );
+        QEventLoop loop;
+        job.connect( &job, SIGNAL(finished(QKeychain::Job*)), &loop, SLOT(quit()) );
+        job.start();
+        loop.exec();
+     if ( job.error() ) {
+            std::cerr << "Storing binary password failed: "
+                      << qPrintable(job.errorString()) << std::endl;
+            return 1;
+        }
+        std::cout << "Password stored successfully" << std::endl;
     } else if ( *it == QLatin1String("restore") ) {
         if ( ++it == args.constEnd() )
             return printUsage();


### PR DESCRIPTION
Fixed gnome keyring password read / write functions.
The password was previously written with the correct mode but on reading the information was lost.

NOTE: This pull will break existing entries as it requires a new attribute for each entyr.