### PR TITLE
change Kwallet on undetected Desktops to Kwallet5

### DIFF
--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -103,7 +103,7 @@ static KeyringBackend detectKeyringBackend()
         if ( GnomeKeyring::isAvailable() ) {
             return Backend_GnomeKeyring;
         } else {
-            return Backend_Kwallet4;
+            return Backend_Kwallet5;
         }
     }
 


### PR DESCRIPTION
This changes the used kwallet version to Backend_Kwallet5 on undetected Desktops.
This enables users of LXQT to use Kwallet5. 
Tested and working on Archlinux https://www.archlinux.org/packages/community/x86_64/qtkeychain-qt5/ just including the above change.