### PR TITLE
Use kwallet4 on LXQt

### DIFF
--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -37,6 +37,7 @@ enum DesktopEnvironment {
     DesktopEnv_Plasma5,
     DesktopEnv_Unity,
     DesktopEnv_Xfce,
+    DesktopEnv_Lxqt,
     DesktopEnv_Other
 };
 
@@ -63,6 +64,8 @@ static DesktopEnvironment detectDesktopEnvironment() {
         return DesktopEnv_Unity;
     } else if ( xdgCurrentDesktop == "KDE" ) {
         return getKdeVersion();
+    } else if ( xdgCurrentDesktop == "LXQt" ) {
+        return DesktopEnv_Lxqt;
     }
 
     QByteArray desktopSession = qgetenv("DESKTOP_SESSION");
@@ -89,6 +92,7 @@ static KeyringBackend detectKeyringBackend()
 {
     switch (detectDesktopEnvironment()) {
     case DesktopEnv_Kde4:
+    case DesktopEnv_Lxqt:
         return Backend_Kwallet4;
         break;
     case DesktopEnv_Plasma5:


### PR DESCRIPTION
LXQt is a Qt environment and gnome-keyring feels alien.

Also idea: would you accept a patch which allows user to override auto-detection using an environment variable? I know it's now possible to override XDG_CURRENT_DESKTOP but this has other unwanted implications on the app using qtkeychain.