### PR TITLE
Added option to make translations optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,18 @@ Makefile
 libqt5keychain.*
 testclient
 
+#Windows build files
+install_manifest.txt
+*.manifest
+*.lib
+*.exe
+
 #Mac build files
 qtkeychain.xcodeproj
 qtkeychain.build
 
 #Temporary files
 *.sw?
+*~
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+#CMake files
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+QtKeychainBuildTreeSettings.cmake
+QtKeychainConfig.cmake
+QtKeychainConfigVersion.cmake
+cmake_install.cmake
+
+#Qt files
+moc_keychain.cxx
+moc_keychain.cxx_parameters
+moc_keychain_p.cxx
+moc_keychain_p.cxx_parameters
+
+#General build files
+Debug
+Release
+
+#Mac build files
+qtkeychain.xcodeproj
+qtkeychain.build
+
+#Temporary files
+*.sw?

--- a/.gitignore
+++ b/.gitignore
@@ -2,20 +2,33 @@
 CMakeCache.txt
 CMakeFiles
 CMakeScripts
+cmake_install.cmake
+
+#Keychain temporary files
+Qt5KeychainBuildTreeSettings.cmake
+Qt5KeychainConfig.cmake
+Qt5KeychainConfigVersion.cmake
 QtKeychainBuildTreeSettings.cmake
 QtKeychainConfig.cmake
 QtKeychainConfigVersion.cmake
-cmake_install.cmake
+kwallet_interface.cpp
+kwallet_interface.h
+kwallet_interface.moc
+moc_keychain.*
+moc_keychain_p.*
 
 #Qt files
-moc_keychain.cxx
-moc_keychain.cxx_parameters
-moc_keychain_p.cxx
-moc_keychain_p.cxx_parameters
+*_parameters
+*.qm
 
 #General build files
 Debug
 Release
+Makefile
+
+#Linux build files
+libqt5keychain.*
+testclient
 
 #Mac build files
 qtkeychain.xcodeproj
@@ -23,3 +36,5 @@ qtkeychain.build
 
 #Temporary files
 *.sw?
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 list(APPEND qtkeychain_LIBRARIES ${QTCORE_LIBRARIES})
 set(qtkeychain_SOURCES
     keychain.cpp
+    qkeychain_export.h
+    keychain.h
 )
 
 add_definitions( -Wall )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if(NOT QTKEYCHAIN_STATIC)
     target_link_libraries(${QTKEYCHAIN_TARGET_NAME} ${qtkeychain_LIBRARIES})
 else()
     add_library(${QTKEYCHAIN_TARGET_NAME} STATIC ${qtkeychain_SOURCES} ${qtkeychain_MOC_OUTFILES} ${qtkeychain_QM_FILES})
-    set_target_properties(${QTKEYCHAIN_TARGET_NAME} PROPERTIES COMPILE_DEFINITIONS QKEYCHAIN_STATICLIB)
+    set_target_properties(${QTKEYCHAIN_TARGET_NAME} PROPERTIES COMPILE_DEFINITIONS QKEYCHAIN_STATICLIB )
 endif()
 
 set_target_properties(${QTKEYCHAIN_TARGET_NAME} PROPERTIES
@@ -187,6 +187,7 @@ install(TARGETS ${QTKEYCHAIN_TARGET_NAME}
 
 add_executable( testclient testclient.cpp )
 target_link_libraries( testclient ${QTKEYCHAIN_TARGET_NAME} ${qtkeychain_LIBRARIES})
+set_target_properties( testclient PROPERTIES COMPILE_DEFINITIONS QKEYCHAIN_STATICLIB )
 
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(GNUInstallDirs)
 
 option(BUILD_WITH_QT4 "Build qtkeychain with Qt4 no matter if Qt5 was found" OFF)
 option(BUILD_TRANSLATIONS "Build translations" ON)
+option(QTKEYCHAIN_STATIC "Build static library" OFF)
 
 if (WIN32)
     option(USE_CREDENTIAL_STORE "Build with windows CredentialStore support" ON)
@@ -122,7 +123,7 @@ endif()
 if(UNIX AND NOT APPLE)
     list(APPEND qtkeychain_SOURCES keychain_unix.cpp gnomekeyring.cpp)
     qt_add_dbus_interface(qtkeychain_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/org.kde.KWallet.xml kwallet_interface KWalletInterface)
-    list(APPEND qtkeychain_LIBRARIES ${QTDBUS_LIBRARIES})
+    list(APPEND qtkeychain_LIBRARIES ${QTDBUS_LIBRARIES} )
 endif()
 
 QT_WRAP_CPP(qtkeychain_MOC_OUTFILES keychain.h keychain_p.h)
@@ -185,7 +186,7 @@ install(TARGETS ${QTKEYCHAIN_TARGET_NAME}
 )
 
 add_executable( testclient testclient.cpp )
-target_link_libraries( testclient ${QTKEYCHAIN_TARGET_NAME})
+target_link_libraries( testclient ${QTKEYCHAIN_TARGET_NAME} ${qtkeychain_LIBRARIES})
 
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,12 @@ if (WIN32)
 endif()
 
 if( NOT BUILD_WITH_QT4 )
+
+    #Make it possible to point out where the QT is installed
+    if ( QTDIR ) 
+	list ( APPEND CMAKE_PREFIX_PATH ${QTDIR} )
+    endif( QTDIR )
+
     # try Qt5 first, and prefer that if found
     find_package(Qt5Core QUIET)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${PROJECT_SOURCE_DIR}/cmake/Module
 include(GNUInstallDirs)
 
 option(BUILD_WITH_QT4 "Build qtkeychain with Qt4 no matter if Qt5 was found" OFF)
+option(BUILD_TRANSLATIONS "Build translations" ON)
 
 if (WIN32)
     option(USE_CREDENTIAL_STORE "Build with windows CredentialStore support" ON)
@@ -89,7 +90,7 @@ set(qtkeychain_SOURCES
     keychain.cpp
 )
 
-ADD_DEFINITIONS( -Wall )
+add_definitions( -Wall )
 
 if(WIN32)
     list(APPEND qtkeychain_SOURCES keychain_win.cpp)
@@ -124,26 +125,28 @@ set(qtkeychain_TR_FILES
 )
 
 file(GLOB qtkeychain_TR_SOURCES *.cpp *.h *.ui)
-qt_create_translation(qtkeychain_MESSAGES ${qtkeychain_TR_SOURCES} ${qtkeychain_TR_FILES})
-qt_add_translation(qtkeychain_QM_FILES ${qtkeychain_TR_FILES})
-add_custom_target(messages DEPENDS ${qtkeychain_MESSAGES})
-add_custom_target(translations DEPENDS ${qtkeychain_QM_FILES})
+if ( BUILD_TRANSLATIONS )
+    qt_create_translation(qtkeychain_MESSAGES ${qtkeychain_TR_SOURCES} ${qtkeychain_TR_FILES})
+    qt_add_translation(qtkeychain_QM_FILES ${qtkeychain_TR_FILES})
+    add_custom_target(messages DEPENDS ${qtkeychain_MESSAGES})
+    add_custom_target(translations DEPENDS ${qtkeychain_QM_FILES})
 
-if(NOT QT_TRANSLATIONS_DIR)
-    # If this directory is missing, we are in a Qt5 environment.
-    # Extract the qmake executable location
-    get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
-    # Ask Qt5 where to put the translations
-    execute_process( COMMAND ${QT5_QMAKE_EXECUTABLE} -query QT_INSTALL_TRANSLATIONS
-        OUTPUT_VARIABLE qt_translations_dir OUTPUT_STRIP_TRAILING_WHITESPACE )
-    # make sure we have / and not \ as qmake gives on windows
-    FILE(TO_CMAKE_PATH "${qt_translations_dir}" qt_translations_dir)
-    SET(QT_TRANSLATIONS_DIR ${qt_translations_dir} CACHE PATH "The
-    location of the Qt translations" FORCE)
-endif()
+    if(NOT QT_TRANSLATIONS_DIR)
+	# If this directory is missing, we are in a Qt5 environment.
+	# Extract the qmake executable location
+	get_target_property(QT5_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
+	# Ask Qt5 where to put the translations
+	execute_process( COMMAND ${QT5_QMAKE_EXECUTABLE} -query QT_INSTALL_TRANSLATIONS
+	    OUTPUT_VARIABLE qt_translations_dir OUTPUT_STRIP_TRAILING_WHITESPACE )
+	# make sure we have / and not \ as qmake gives on windows
+	file( TO_CMAKE_PATH "${qt_translations_dir}" qt_translations_dir)
+	set( QT_TRANSLATIONS_DIR ${qt_translations_dir} CACHE PATH
+	     "The location of the Qt translations" FORCE)
+    endif()
 
-install(FILES ${qtkeychain_QM_FILES}
-        DESTINATION ${QT_TRANSLATIONS_DIR})
+    install(FILES ${qtkeychain_QM_FILES}
+	    DESTINATION ${QT_TRANSLATIONS_DIR})
+endif( BUILD_TRANSLATIONS )
 
 set(QTKEYCHAIN_TARGET_NAME qt${QTKEYCHAIN_VERSION_INFIX}keychain)
 if(NOT QTKEYCHAIN_STATIC)


### PR DESCRIPTION
I had a problem building on mac, as the QTDIR/lib was not in my DYLD_LIBRARY_PATH, and lupdate did hence not load.

I do not need the translations, so I added an option to skip the translation all together. The ${qtkeychain_QM_FILES} variable will be empty, so there is no harm if it says in the add_library call.