### PR TITLE
Store encrypted passwords on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,17 @@ endif()
 if (Qt5Core_FOUND)
   set(QTKEYCHAIN_VERSION_INFIX 5)
 
+  if(ANDROID)
+    if(Qt5Core_VERSION VERSION_LESS 5.7)
+        find_package(Qt5Core REQUIRED Private)
+        include_directories(${Qt5Core_PRIVATE_INCLUDE_DIRS})
+    endif()
+
+    find_package(Qt5AndroidExtras REQUIRED)
+    include_directories(${Qt5AndroidExtras_INCLUDE_DIRS})
+    set(QTANDROIDEXTRAS_LIBRARIES ${Qt5AndroidExtras_LIBRARIES})
+  endif()
+
   if(UNIX AND NOT APPLE AND NOT ANDROID)
     find_package(Qt5DBus REQUIRED)
     include_directories(${Qt5DBus_INCLUDE_DIRS})
@@ -145,6 +156,12 @@ if(APPLE)
 
     find_library(SECURITY_LIBRARY Security REQUIRED)
     list(APPEND qtkeychain_LIBRARIES ${SECURITY_LIBRARY})
+endif()
+
+if(ANDROID)
+    set(CMAKE_CXX_STANDARD 11)
+    list(APPEND qtkeychain_SOURCES keychain_android.cpp androidkeystore.cpp plaintextstore.cpp)
+    list(APPEND qtkeychain_LIBRARIES ${QTANDROIDEXTRAS_LIBRARIES} )
 endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)

--- a/androidkeystore.cpp
+++ b/androidkeystore.cpp
@@ -1,0 +1,303 @@
+#include "androidkeystore_p.h"
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+#include "private/qjni_p.h"
+#endif
+
+#include <QAndroidJniEnvironment>
+
+using namespace QKeychain;
+
+using namespace android::content;
+using namespace android::security;
+
+using namespace java::io;
+using namespace java::lang;
+using namespace java::math;
+using namespace java::util;
+using namespace java::security;
+using namespace java::security::spec;
+
+using namespace javax::crypto;
+using namespace javax::security::auth::x500;
+using namespace javax::security::cert;
+
+const BigInteger BigInteger::ONE = BigInteger::getStaticObjectField("java/math/BigInteger", "ONE", "Ljava/math/BigInteger;");
+
+const int Calendar::YEAR = Calendar::getStaticField<jint>("java/util/Calendar", "YEAR");
+
+const int Cipher::DECRYPT_MODE = Cipher::getStaticField<jint>("javax/crypto/Cipher", "DECRYPT_MODE");
+const int Cipher::ENCRYPT_MODE = Cipher::getStaticField<jint>("javax/crypto/Cipher", "ENCRYPT_MODE");
+
+namespace {
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 7, 0)
+
+struct JNIObject
+{
+    JNIObject(QSharedPointer<QJNIObjectPrivate> d): d(d) {}
+
+    static JNIObject fromLocalRef(jobject o)
+    {
+        return JNIObject(QSharedPointer<QJNIObjectPrivate>::create(QJNIObjectPrivate::fromLocalRef(o)));
+    }
+
+    jobject object() const { return d->object(); }
+    QSharedPointer<QJNIObjectPrivate> d;
+};
+
+#else
+
+using JNIObject = QAndroidJniObject;
+
+#endif
+
+QByteArray fromArray(const jbyteArray array)
+{
+    QAndroidJniEnvironment env;
+    jbyte *const bytes = env->GetByteArrayElements(array, Q_NULLPTR);
+    const QByteArray result(reinterpret_cast<const char *>(bytes), env->GetArrayLength(array));
+    env->ReleaseByteArrayElements(array, bytes, JNI_ABORT);
+    return result;
+}
+
+JNIObject toArray(const QByteArray &bytes)
+{
+    QAndroidJniEnvironment env;
+    const int length = bytes.length();
+    JNIObject array = JNIObject::fromLocalRef(env->NewByteArray(length));
+    env->SetByteArrayRegion(static_cast<jbyteArray>(array.object()),
+                            0, length, reinterpret_cast<const jbyte *>(bytes.constData()));
+    return array;
+}
+
+}
+
+bool Object::handleExceptions()
+{
+    QAndroidJniEnvironment env;
+
+    if (env->ExceptionCheck()) {
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return false;
+    }
+
+    return true;
+}
+
+
+KeyPairGenerator KeyPairGenerator::getInstance(const QString &algorithm, const QString &provider)
+{
+    return handleExceptions(callStaticObjectMethod("java/security/KeyPairGenerator", "getInstance",
+                                                   "(Ljava/lang/String;Ljava/lang/String;)Ljava/security/KeyPairGenerator;",
+                                                   fromString(algorithm).object(), fromString(provider).object()));
+}
+
+KeyPair KeyPairGenerator::generateKeyPair() const
+{
+    return handleExceptions(callObjectMethod("generateKeyPair", "()Ljava/security/KeyPair;"));
+}
+
+bool KeyPairGenerator::initialize(const AlgorithmParameterSpec &spec) const
+{
+    callMethod<void>("initialize", "(Ljava/security/spec/AlgorithmParameterSpec;)V", spec.object());
+    return handleExceptions();
+}
+
+bool KeyStore::containsAlias(const QString &alias) const
+{
+    return handleExceptions(callMethod<jboolean>("containsAlias", "(Ljava/lang/String;)Z",
+                                                 fromString(alias).object()));
+}
+
+bool KeyStore::deleteEntry(const QString &alias) const
+{
+    callMethod<void>("deleteEntry", "(Ljava/lang/String;)Z", fromString(alias).object());
+    return handleExceptions();
+}
+
+KeyStore KeyStore::getInstance(const QString &type)
+{
+    return handleExceptions(callStaticObjectMethod("java/security/KeyStore", "getInstance",
+                                                   "(Ljava/lang/String;)Ljava/security/KeyStore;",
+                                                   fromString(type).object()));
+}
+
+KeyStore::Entry KeyStore::getEntry(const QString &alias, const KeyStore::ProtectionParameter &param) const
+{
+    return handleExceptions(callObjectMethod("getEntry",
+                                             "(Ljava/lang/String;Ljava/security/KeyStore$ProtectionParameter;)Ljava/security/KeyStore$Entry;",
+                                             fromString(alias).object(), param.object()));
+}
+
+bool KeyStore::load(const KeyStore::LoadStoreParameter &param) const
+{
+    callMethod<void>("load", "(Ljava/security/KeyStore$LoadStoreParameter;)V", param.object());
+    return handleExceptions();
+}
+
+
+Calendar Calendar::getInstance()
+{
+    return handleExceptions(callStaticObjectMethod("java/util/Calendar", "getInstance",
+                                                   "()Ljava/util/Calendar;"));
+
+}
+
+bool Calendar::add(int field, int amount) const
+{
+    callMethod<void>("add", "(II)V", field, amount);
+    return handleExceptions();
+}
+
+Date Calendar::getTime() const
+{
+    return handleExceptions(callObjectMethod("getTime", "()Ljava/util/Date;"));
+}
+
+KeyPairGeneratorSpec::Builder::Builder(const Context &context)
+    : Object(QAndroidJniObject("android/security/KeyPairGeneratorSpec$Builder",
+                               "(Landroid/content/Context;)V",
+                               context.object()))
+{
+    handleExceptions();
+}
+
+KeyPairGeneratorSpec::Builder KeyPairGeneratorSpec::Builder::setAlias(const QString &alias) const
+{
+    return handleExceptions(callObjectMethod("setAlias",
+                                             "(Ljava/lang/String;)Landroid/security/KeyPairGeneratorSpec$Builder;",
+                                             fromString(alias).object()));
+}
+
+KeyPairGeneratorSpec::Builder KeyPairGeneratorSpec::Builder::setSubject(const X500Principal &subject) const
+{
+    return handleExceptions(callObjectMethod("setSubject",
+                                             "(Ljavax/security/auth/x500/X500Principal;)Landroid/security/KeyPairGeneratorSpec$Builder;",
+                                             subject.object()));
+}
+
+KeyPairGeneratorSpec::Builder KeyPairGeneratorSpec::Builder::setSerialNumber(const BigInteger &serial) const
+{
+    return handleExceptions(callObjectMethod("setSerialNumber",
+                                             "(Ljava/math/BigInteger;)Landroid/security/KeyPairGeneratorSpec$Builder;",
+                                             serial.object()));
+}
+
+KeyPairGeneratorSpec::Builder KeyPairGeneratorSpec::Builder::setStartDate(const Date &date) const
+{
+    return handleExceptions(callObjectMethod("setStartDate",
+                                             "(Ljava/util/Date;)Landroid/security/KeyPairGeneratorSpec$Builder;",
+                                             date.object()));
+}
+
+KeyPairGeneratorSpec::Builder KeyPairGeneratorSpec::Builder::setEndDate(const Date &date) const
+{
+    return handleExceptions(callObjectMethod("setEndDate",
+                                             "(Ljava/util/Date;)Landroid/security/KeyPairGeneratorSpec$Builder;",
+                                             date.object()));
+}
+
+KeyPairGeneratorSpec KeyPairGeneratorSpec::Builder::build() const
+{
+    return handleExceptions(callObjectMethod("build", "()Landroid/security/KeyPairGeneratorSpec;"));
+}
+
+X500Principal::X500Principal(const QString &name)
+    : Object(QAndroidJniObject("javax/security/auth/x500/X500Principal",
+                               "(Ljava/lang/String;)V",
+                               fromString(name).object()))
+{
+    handleExceptions();
+}
+
+Certificate KeyStore::PrivateKeyEntry::getCertificate() const
+{
+    return handleExceptions(callObjectMethod("getCertificate", "()Ljava/security/cert/Certificate;"));
+}
+
+PrivateKey KeyStore::PrivateKeyEntry::getPrivateKey() const
+{
+    return handleExceptions(callObjectMethod("getPrivateKey", "()Ljava/security/PrivateKey;"));
+}
+
+PublicKey Certificate::getPublicKey() const
+{
+    return handleExceptions(callObjectMethod("getPublicKey", "()Ljava/security/PublicKey;"));
+}
+
+ByteArrayInputStream::ByteArrayInputStream(const QByteArray &bytes)
+    : InputStream(QAndroidJniObject("java/io/ByteArrayInputStream", "([B)V", toArray(bytes).object()))
+{
+}
+
+ByteArrayOutputStream::ByteArrayOutputStream()
+    : OutputStream(QAndroidJniObject("java/io/ByteArrayOutputStream"))
+{
+    handleExceptions();
+}
+
+QByteArray ByteArrayOutputStream::toByteArray() const
+{
+    const QAndroidJniObject wrapper = callObjectMethod<jbyteArray>("toByteArray");
+
+    if (!handleExceptions())
+        return QByteArray();
+
+    return fromArray(static_cast<jbyteArray>(wrapper.object()));
+}
+
+int InputStream::read() const
+{
+    return handleExceptions(callMethod<int>("read"), -1);
+}
+
+bool OutputStream::write(const QByteArray &bytes) const
+{
+    callMethod<void>("write", "([B)V", toArray(bytes).object());
+    return handleExceptions();
+}
+
+bool OutputStream::close() const
+{
+    callMethod<void>("close");
+    return handleExceptions();
+}
+
+bool OutputStream::flush() const
+{
+    callMethod<void>("flush");
+    return handleExceptions();
+}
+
+Cipher Cipher::getInstance(const QString &transformation, const QString &provider)
+{
+    return handleExceptions(callStaticObjectMethod("javax/crypto/Cipher", "getInstance",
+                                                   "(Ljava/lang/String;Ljava/lang/String;)Ljavax/crypto/Cipher;",
+                                                   fromString(transformation).object(),
+                                                   fromString(provider).object()));
+}
+
+bool Cipher::init(int opMode, const Key &key) const
+{
+    callMethod<void>("init", "(ILjava/security/Key;)V", opMode, key.object());
+    return handleExceptions();
+}
+
+
+CipherOutputStream::CipherOutputStream(const OutputStream &stream, const Cipher &cipher)
+    : FilterOutputStream(QAndroidJniObject("javax/crypto/CipherOutputStream",
+                                           "(Ljava/io/OutputStream;Ljavax/crypto/Cipher;)V",
+                                           stream.object(), cipher.object()))
+{
+    handleExceptions();
+}
+
+CipherInputStream::CipherInputStream(const InputStream &stream, const Cipher &cipher)
+    : FilterInputStream(QAndroidJniObject("javax/crypto/CipherInputStream",
+                                          "(Ljava/io/InputStream;Ljavax/crypto/Cipher;)V",
+                                          stream.object(), cipher.object()))
+{
+    handleExceptions();
+}

--- a/androidkeystore_p.h
+++ b/androidkeystore_p.h
@@ -1,0 +1,371 @@
+/******************************************************************************
+ *   Copyright (C) 2016 Mathias Hasselmann <mathias.hasselmann@kdab.com>      *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful, but        *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE. For licensing and distribution        *
+ * details, check the accompanying file 'COPYING'.                            *
+ *****************************************************************************/
+
+#ifndef QTKEYCHAIN_ANDROIDKEYSTORE_P_H
+#define QTKEYCHAIN_ANDROIDKEYSTORE_P_H
+
+#include <QAndroidJniObject>
+
+namespace QKeychain {
+
+namespace javax {
+namespace security {
+
+namespace auth { namespace x500 { class X500Principal; } }
+namespace cert { class Certificate; }
+
+}
+}
+
+namespace java {
+namespace lang {
+
+class Object : protected QAndroidJniObject
+{
+public:
+    inline Object(jobject object) : QAndroidJniObject(object) {}
+    inline Object(const QAndroidJniObject &object) : QAndroidJniObject(object) {}
+    inline operator bool() const { return isValid(); }
+
+    using QAndroidJniObject::object;
+    using QAndroidJniObject::toString;
+
+protected:
+    static bool handleExceptions();
+
+    template<typename T>
+    static T handleExceptions(const T &result, const T &resultOnError = T());
+};
+
+template<typename T>
+inline T Object::handleExceptions(const T &result, const T &resultOnError)
+{
+    if (!handleExceptions())
+        return resultOnError;
+
+    return result;
+}
+
+} // namespace lang
+
+namespace io {
+
+class InputStream : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    int read() const;
+};
+
+class ByteArrayInputStream : public InputStream
+{
+public:
+    using InputStream::InputStream;
+
+    explicit ByteArrayInputStream(const QByteArray &bytes);
+};
+
+class FilterInputStream : public InputStream
+{
+public:
+    using InputStream::InputStream;
+};
+
+class OutputStream : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    bool write(const QByteArray &bytes) const;
+    bool flush() const;
+    bool close() const;
+};
+
+class ByteArrayOutputStream : public OutputStream
+{
+public:
+    using OutputStream::OutputStream;
+
+    ByteArrayOutputStream();
+
+    QByteArray toByteArray() const;
+};
+
+class FilterOutputStream : public OutputStream
+{
+public:
+    using OutputStream::OutputStream;
+};
+
+} // namespace io
+
+namespace math {
+
+class BigInteger : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    static const BigInteger ZERO;
+    static const BigInteger ONE;
+    static const BigInteger TEN;
+};
+
+} // namespace math
+
+namespace util {
+
+class Date : public java::lang::Object
+{
+public:
+    using Object::Object;
+};
+
+class Calendar : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    static const int YEAR;
+    static const int MONTH;
+    static const int DAY;
+    static const int HOUR;
+    static const int MINUTE;
+    static const int SECOND;
+    static const int MILLISECOND;
+
+    static Calendar getInstance();
+
+    bool add(int field, int amount) const;
+    Date getTime() const;
+};
+
+} // namespace util
+
+namespace security {
+namespace spec {
+
+class AlgorithmParameterSpec : public java::lang::Object
+{
+public:
+    using Object::Object;
+};
+
+} // namespace spec
+
+class Key : public java::lang::Object
+{
+public:
+    using Object::Object;
+};
+
+class PrivateKey : public Key
+{
+public:
+    using Key::Key;
+
+    PrivateKey(const Key &init): Key(init) {}
+};
+
+class PublicKey : public Key
+{
+public:
+    using Key::Key;
+
+    PublicKey(const Key &init): Key(init) {}
+};
+
+class KeyPair : public java::lang::Object
+{
+public:
+    using Object::Object;
+};
+
+class KeyPairGenerator : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    static KeyPairGenerator getInstance(const QString &algorithm, const QString &provider);
+    KeyPair generateKeyPair() const;
+    bool initialize(const spec::AlgorithmParameterSpec &spec) const;
+
+};
+
+class KeyStore : public java::lang::Object
+{
+public:
+    class Entry : public java::lang::Object
+    {
+    public:
+        using Object::Object;
+    };
+
+    class PrivateKeyEntry : public Entry
+    {
+    public:
+        using Object::Object;
+
+        inline PrivateKeyEntry(const Entry &init): Entry(init) {}
+
+        javax::security::cert::Certificate getCertificate() const;
+        java::security::PrivateKey getPrivateKey() const;
+    };
+
+    class LoadStoreParameter : public java::lang::Object
+    {
+    public:
+        using Object::Object;
+    };
+
+    class ProtectionParameter : public java::lang::Object
+    {
+    public:
+        using Object::Object;
+    };
+
+    using Object::Object;
+
+    bool containsAlias(const QString &alias) const;
+    bool deleteEntry(const QString &alias) const;
+    static KeyStore getInstance(const QString &type);
+    Entry getEntry(const QString &alias, const ProtectionParameter &param = Q_NULLPTR) const;
+    bool load(const LoadStoreParameter &param = Q_NULLPTR) const;
+};
+
+namespace interfaces {
+
+class RSAPrivateKey : public PrivateKey
+{
+public:
+    using PrivateKey::PrivateKey;
+
+    RSAPrivateKey(const PrivateKey &init): PrivateKey(init) {}
+};
+
+class RSAPublicKey : public PublicKey
+{
+public:
+    using PublicKey::PublicKey;
+
+    RSAPublicKey(const PublicKey &init): PublicKey(init) {}
+};
+
+} // namespace interfaces
+
+} // namespace security
+} // namespace java
+
+namespace android {
+namespace content {
+
+class Context : public java::lang::Object
+{
+public:
+    using Object::Object;
+};
+
+} // namespace content
+
+namespace security {
+
+class KeyPairGeneratorSpec : public java::security::spec::AlgorithmParameterSpec
+{
+public:
+    class Builder : public java::lang::Object
+    {
+    public:
+        using Object::Object;
+
+        explicit Builder(const android::content::Context &context);
+
+        Builder setAlias(const QString &alias) const;
+        Builder setSubject(const javax::security::auth::x500::X500Principal &subject) const;
+        Builder setSerialNumber(const java::math::BigInteger &serial) const;
+        Builder setStartDate(const java::util::Date &date) const;
+        Builder setEndDate(const java::util::Date &date) const;
+        KeyPairGeneratorSpec build() const;
+
+    };
+
+    using AlgorithmParameterSpec::AlgorithmParameterSpec;
+};
+
+} // namespace security
+} // namespace android
+
+namespace javax {
+namespace crypto {
+
+class Cipher : public java::lang::Object
+{
+public:
+    static const int DECRYPT_MODE;
+    static const int ENCRYPT_MODE;
+
+    using Object::Object;
+
+    static Cipher getInstance(const QString &transformation, const QString &provider);
+    bool init(int opMode, const java::security::Key &key) const;
+};
+
+class CipherInputStream : public java::io::FilterInputStream
+{
+public:
+    using FilterInputStream::FilterInputStream;
+
+    explicit CipherInputStream(const InputStream &stream, const Cipher &cipher);
+};
+
+class CipherOutputStream : public java::io::FilterOutputStream
+{
+public:
+    using FilterOutputStream::FilterOutputStream;
+
+    explicit CipherOutputStream(const OutputStream &stream, const Cipher &cipher);
+};
+
+}
+
+namespace security {
+namespace auth {
+namespace x500 {
+
+class X500Principal;
+
+class X500Principal : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    explicit X500Principal(const QString &name);
+};
+
+} // namespace x500
+} // namespace auth
+
+namespace cert {
+
+class Certificate : public java::lang::Object
+{
+public:
+    using Object::Object;
+
+    java::security::PublicKey getPublicKey() const;
+};
+
+} // namespace cert
+
+} // namespace security
+} // namespace javax
+
+} // namespace QKeychain
+
+#endif // QTKEYCHAIN_ANDROIDKEYSTORE_P_H

--- a/keychain_android.cpp
+++ b/keychain_android.cpp
@@ -1,0 +1,184 @@
+/******************************************************************************
+ *   Copyright (C) 2016 Mathias Hasselmann <mathias.hasselmann@kdab.com>      *
+ *                                                                            *
+ * This program is distributed in the hope that it will be useful, but        *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY *
+ * or FITNESS FOR A PARTICULAR PURPOSE. For licensing and distribution        *
+ * details, check the accompanying file 'COPYING'.                            *
+ *****************************************************************************/
+
+#include "keychain_p.h"
+
+#include "androidkeystore_p.h"
+#include "plaintextstore_p.h"
+
+#include <QtAndroid>
+
+using namespace QKeychain;
+
+using android::content::Context;
+using android::security::KeyPairGeneratorSpec;
+
+using java::io::ByteArrayInputStream;
+using java::io::ByteArrayOutputStream;
+using java::security::interfaces::RSAPrivateKey;
+using java::security::interfaces::RSAPublicKey;
+using java::security::KeyPair;
+using java::security::KeyPairGenerator;
+using java::security::KeyStore;
+using java::util::Calendar;
+
+using javax::crypto::Cipher;
+using javax::crypto::CipherInputStream;
+using javax::crypto::CipherOutputStream;
+using javax::security::auth::x500::X500Principal;
+
+namespace {
+
+inline QString makeAlias(const QString &service, const QString &key)
+{
+    return service + QLatin1Char('/') + key;
+}
+
+}
+
+void ReadPasswordJobPrivate::scheduledStart()
+{
+    PlainTextStore plainTextStore(q->service(), q->settings());
+
+    if (!plainTextStore.contains(q->key())) {
+        q->emitFinishedWithError(Error::EntryNotFound, tr("Entry not found"));
+        return;
+    }
+
+    const QByteArray &encryptedData = plainTextStore.readData(q->key());
+    const KeyStore keyStore = KeyStore::getInstance(QStringLiteral("AndroidKeyStore"));
+
+    if (!keyStore || !keyStore.load()) {
+        q->emitFinishedWithError(Error::AccessDenied, tr("Could not open keystore"));
+        return;
+    }
+
+    const auto &alias = makeAlias(q->service(), q->key());
+    const KeyStore::PrivateKeyEntry entry = keyStore.getEntry(alias);
+
+    if (!entry) {
+        q->emitFinishedWithError(Error::AccessDenied, tr("Could not retreive private key from keystore"));
+        return;
+    }
+
+    const Cipher cipher = Cipher::getInstance(QStringLiteral("RSA/ECB/PKCS1Padding"),
+                                              QStringLiteral("AndroidOpenSSL"));
+
+    if (!cipher || !cipher.init(Cipher::DECRYPT_MODE, entry.getPrivateKey())) {
+        q->emitFinishedWithError(Error::OtherError, tr("Could not create decryption cipher"));
+        return;
+    }
+
+    QByteArray plainData;
+    const CipherInputStream inputStream(ByteArrayInputStream(encryptedData), cipher);
+
+    for (int nextByte; (nextByte = inputStream.read()) != -1; )
+        plainData.append(nextByte);
+
+    mode = plainTextStore.readMode(q->key());
+    data = plainData;
+    q->emitFinished();
+}
+
+void WritePasswordJobPrivate::scheduledStart()
+{
+    const KeyStore keyStore = KeyStore::getInstance(QStringLiteral("AndroidKeyStore"));
+
+    if (!keyStore || !keyStore.load()) {
+        q->emitFinishedWithError(Error::AccessDenied, tr("Could not open keystore"));
+        return;
+    }
+
+    const auto &alias = makeAlias(q->service(), q->key());
+    if (!keyStore.containsAlias(alias)) {
+        const Calendar start = Calendar::getInstance();
+        const Calendar end = Calendar::getInstance();
+        end.add(Calendar::YEAR, 99);
+
+        const KeyPairGeneratorSpec spec =
+                KeyPairGeneratorSpec::Builder(Context(QtAndroid::androidActivity())).
+                setAlias(alias).
+                setSubject(X500Principal(QStringLiteral("CN=QtKeychain, O=Android Authority"))).
+                setSerialNumber(java::math::BigInteger::ONE).
+                setStartDate(start.getTime()).
+                setEndDate(end.getTime()).
+                build();
+
+        const KeyPairGenerator generator = KeyPairGenerator::getInstance(QStringLiteral("RSA"),
+                                                                         QStringLiteral("AndroidKeyStore"));
+
+        if (!generator) {
+            q->emitFinishedWithError(Error::OtherError, tr("Could not create private key generator"));
+            return;
+        }
+
+        generator.initialize(spec);
+
+        if (!generator.generateKeyPair()) {
+            q->emitFinishedWithError(Error::OtherError, tr("Could not generate new private key"));
+            return;
+        }
+    }
+
+    const KeyStore::PrivateKeyEntry entry = keyStore.getEntry(alias);
+
+    if (!entry) {
+        q->emitFinishedWithError(Error::AccessDenied, tr("Could not retreive private key from keystore"));
+        return;
+    }
+
+    const RSAPublicKey publicKey = entry.getCertificate().getPublicKey();
+    const Cipher cipher = Cipher::getInstance(QStringLiteral("RSA/ECB/PKCS1Padding"),
+                                              QStringLiteral("AndroidOpenSSL"));
+
+    if (!cipher || !cipher.init(Cipher::ENCRYPT_MODE, publicKey)) {
+        q->emitFinishedWithError(Error::OtherError, tr("Could not create encryption cipher"));
+        return;
+    }
+
+    ByteArrayOutputStream outputStream;
+    CipherOutputStream cipherOutputStream(outputStream, cipher);
+
+    if (!cipherOutputStream.write(data) || !cipherOutputStream.close()) {
+        q->emitFinishedWithError(Error::OtherError, tr("Could not encrypt data"));
+        return;
+    }
+
+    PlainTextStore plainTextStore(q->service(), q->settings());
+    plainTextStore.write(q->key(), outputStream.toByteArray(), mode);
+
+    if (plainTextStore.error() != NoError)
+        q->emitFinishedWithError(plainTextStore.error(), plainTextStore.errorString());
+    else
+        q->emitFinished();
+}
+
+void DeletePasswordJobPrivate::scheduledStart()
+{
+    const KeyStore keyStore = KeyStore::getInstance(QStringLiteral("AndroidKeyStore"));
+
+    if (!keyStore || !keyStore.load()) {
+        q->emitFinishedWithError(Error::AccessDenied, tr("Could not open keystore"));
+        return;
+    }
+
+    const auto &alias = makeAlias(q->service(), q->key());
+    if (!keyStore.deleteEntry(alias)) {
+        q->emitFinishedWithError(Error::OtherError, tr("Could not remove private key from keystore"));
+        return;
+    }
+
+    PlainTextStore plainTextStore(q->service(), q->settings());
+    plainTextStore.remove(q->key());
+
+    if (plainTextStore.error() != NoError)
+        q->emitFinishedWithError(plainTextStore.error(), plainTextStore.errorString());
+    else
+        q->emitFinished();
+}


### PR DESCRIPTION
As this JNI stuff adds overhead we should decide if we add a build option to disable the encrypted keystore.

C++ 11 is needed because I was way to lazy to also type all the constructor boilerplate for the JNI wrappers. Actually such code should be generated. Working on such tool separately. You might want to wait for it.
