### PR TITLE
Reintroduce minimal qmake support

### DIFF
--- a/keychain.h
+++ b/keychain.h
@@ -9,7 +9,11 @@
 #ifndef KEYCHAIN_H
 #define KEYCHAIN_H
 
+#if !defined(QTKEYCHAIN_NO_EXPORT)
 #include "qkeychain_export.h"
+#else
+#define QKEYCHAIN_EXPORT
+#endif
 
 #include <QtCore/QObject>
 #include <QtCore/QString>

--- a/qt5keychain.pri
+++ b/qt5keychain.pri
@@ -1,0 +1,50 @@
+# Minimal qmake support.
+# This file is provided as is without any warranty.
+# It can break at anytime or be removed without notice.
+
+QT5KEYCHAIN_PWD = $$PWD
+
+CONFIG *= depend_includepath
+DEFINES += QTKEYCHAIN_NO_EXPORT
+#CONFIG += plaintextstore
+
+INCLUDEPATH += \
+    $$PWD/.. \
+    $$QT5KEYCHAIN_PWD
+
+HEADERS += \
+    $$QT5KEYCHAIN_PWD/keychain_p.h \
+    $$QT5KEYCHAIN_PWD/keychain.h
+
+SOURCES *= \
+    $$QT5KEYCHAIN_PWD/keychain.cpp
+
+plaintextstore {
+    HEADERS += $$QT5KEYCHAIN_PWD/plaintextstore_p.h
+    SOURCES += $$QT5KEYCHAIN_PWD/plaintextstore.cpp
+} else {
+    unix:!macx {
+        QT += dbus
+
+        HEADERS += $$QT5KEYCHAIN_PWD/gnomekeyring_p.h
+
+        SOURCES += \
+            $$QT5KEYCHAIN_PWD/gnomekeyring.cpp \
+            $$QT5KEYCHAIN_PWD/keychain_unix.cpp
+    }
+
+    win {
+        HEADERS += $$QT5KEYCHAIN_PWD/libsecret_p.h
+
+        SOURCES += \
+            $$QT5KEYCHAIN_PWD/keychain_win.cpp \
+            $$QT5KEYCHAIN_PWD/libsecret.cpp
+
+        #DBUS_INTERFACES += $$PWD/Keychain/org.kde.KWallet.xml
+    }
+
+    mac {
+        LIBS += "-framework Security" "-framework Foundation"
+        SOURCES += $$QT5KEYCHAIN_PWD/keychain_mac.cpp
+    }
+}


### PR DESCRIPTION
This is a small pri file that tests project can include to get
keychain support quickly.