### PR TITLE
Make the BUILD_WITH_QT4 working again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if( NOT BUILD_WITH_QT4 )
     find_package(Qt5Core QUIET)
 endif()
 
-if (Qt5Core_FOUND)
+if (Qt5Core_FOUND AND NOT BUILD_WITH_QT4)
   set(QTKEYCHAIN_VERSION_INFIX 5)
 
   if(UNIX AND NOT APPLE AND NOT ANDROID)


### PR DESCRIPTION
ECMQueryQmake.cmake checks for Qt5Core too. With this additional check
Qt5Core_FOUND is not working anymore for switch between Qt4/Qt5 build.