### PR TITLE
Fix building on Windows without credential store

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ add_definitions( -Wall )
 
 if(WIN32)
     list(APPEND qtkeychain_SOURCES keychain_win.cpp)
-    if (!USE_CREDENTIAL_STORE)
+    if (NOT USE_CREDENTIAL_STORE)
         list(APPEND qtkeychain_LIBRARIES crypt32)
         list(APPEND qtkeychain_SOURCES plaintextstore.cpp)
     endif()


### PR DESCRIPTION
I noticed that building on Windows with MinGW with `-DUSE_CREDENTIAL_STORE=OFF` fails due to unresolved symbols from `PlainTextStore` class and from `crypt32` library. The correction implemented in the PR fixed that.

P.S. I used `CMake` 3.9.6 so it doesn't seem the problem is due to the use of outdated `CMake`. I was unable to find out what is the meaning of the exclamation mark for `CMake` but it doesn't seem to be logical not.