### PR TITLE
Secret: Don't match the schema name

### DIFF
--- a/libsecret.cpp
+++ b/libsecret.cpp
@@ -10,7 +10,7 @@
 #if defined(HAVE_LIBSECRET)
 const SecretSchema* qtkeychainSchema(void) {
     static const SecretSchema schema = {
-        "org.qt.keychain", SECRET_SCHEMA_NONE,
+        "org.qt.keychain", SECRET_SCHEMA_DONT_MATCH_NAME,
         {
             { "user", SECRET_SCHEMA_ATTRIBUTE_STRING },
             { "server", SECRET_SCHEMA_ATTRIBUTE_STRING },


### PR DESCRIPTION
This makes libsecret not attempt to match on the schema name for lookups
and removes and thereby allows the libsecret backend to read and delete
passwords that were stored with the gnome-keyring backend.

See #114 