### PR TITLE
Include Mandarin (Taiwan) translation

### DIFF
--- a/translations/qtkeychain_zh.ts
+++ b/translations/qtkeychain_zh.ts
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="zh_TW">
+<context>
+    <name>QKeychain::ReadPasswordJobPrivate</name>
+    <message>
+        <location filename="../keychain_unix.cpp" line="119"/>
+        <source>Unknown error</source>
+        <translation>未知的錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="133"/>
+        <source>D-Bus is not running</source>
+        <translation>D-Bus 不在執行中</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="210"/>
+        <source>No keychain service available</source>
+        <translation>沒有可用的鑰匙圈服務</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="212"/>
+        <source>Could not open wallet: %1; %2</source>
+        <translation>無法開啟錢包：%1; %2</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="258"/>
+        <source>Access to keychain denied</source>
+        <translation>鑰匙圈存取被拒絕</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="279"/>
+        <source>Could not determine data type: %1; %2</source>
+        <translation>無法判斷資料型別：%1; %2</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="297"/>
+        <source>Unsupported entry type &apos;Map&apos;</source>
+        <translation>不支援的項目類型 &apos;Map&apos;</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="300"/>
+        <source>Unknown kwallet entry type &apos;%1&apos;</source>
+        <translation>未知的 kwallet 項目類型 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="315"/>
+        <source>Could not read password: %1; %2</source>
+        <translation>無法讀取密碼：%1; %2</translation>
+    </message>
+    <message>
+        <location filename="../keychain_mac.cpp" line="76"/>
+        <source>Password not found</source>
+        <translation>找不到密碼</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="288"/>
+        <location filename="../keychain_win.cpp" line="27"/>
+        <source>Entry not found</source>
+        <translation>找不到項目</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="44"/>
+        <source>Could not decrypt data</source>
+        <translation>無法解密資料</translation>
+    </message>
+</context>
+<context>
+    <name>QKeychain::WritePasswordJobPrivate</name>
+    <message>
+        <location filename="../keychain_unix.cpp" line="336"/>
+        <location filename="../keychain_unix.cpp" line="344"/>
+        <source>Unknown error</source>
+        <translation>未知的錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="359"/>
+        <source>D-Bus is not running</source>
+        <translation>D-Bus 不在執行中</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="400"/>
+        <location filename="../keychain_unix.cpp" line="485"/>
+        <source>Could not open wallet: %1; %2</source>
+        <translation>無法開啟錢包：%1; %2</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="463"/>
+        <source>Access to keychain denied</source>
+        <translation>鑰匙圈存取被拒絕</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="64"/>
+        <source>Could not delete encrypted data from settings: access error</source>
+        <translation>無法從設定刪除加密資料：存取錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="65"/>
+        <source>Could not delete encrypted data from settings: format error</source>
+        <translation>無法從設定刪除加密資料：格式錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="85"/>
+        <source>Encryption failed</source>
+        <translation>加密失敗</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="100"/>
+        <source>Could not store encrypted data in settings: access error</source>
+        <translation>無法將加密資料儲存至設定：存取錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_win.cpp" line="101"/>
+        <source>Could not store encrypted data in settings: format error</source>
+        <translation>無法將加密資料儲存至設定：格式錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../keychain_unix.cpp" line="155"/>
+        <source>Access to keychain denied</source>
+        <translation>鑰匙圈存取被拒絕</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="157"/>
+        <source>No keyring daemon</source>
+        <translation>沒有可用的鑰匙圈背景程式</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="159"/>
+        <source>Already unlocked</source>
+        <translation>已解鎖</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="161"/>
+        <source>No such keyring</source>
+        <translation>鑰匙圈不存在</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="163"/>
+        <source>Bad arguments</source>
+        <translation>引數錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="165"/>
+        <source>I/O error</source>
+        <translation>I/O 錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="167"/>
+        <source>Cancelled</source>
+        <translation>已取消</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="169"/>
+        <source>Keyring already exists</source>
+        <translation>鑰匙圈已存在</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="171"/>
+        <source>No match</source>
+        <translation>無相符項目</translation>
+    </message>
+    <message>
+        <location filename="../keychain_unix.cpp" line="176"/>
+        <source>Unknown error</source>
+        <translation>未知的錯誤</translation>
+    </message>
+    <message>
+        <location filename="../keychain_mac.cpp" line="31"/>
+        <location filename="../keychain_mac.cpp" line="33"/>
+        <source>%1 (OSStatus %2)</source>
+        <translation>%1 (OSStatus %2)</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Mandarin (Taiwan, zh-TW) locale translation. Wording matches `gnome-keyring` convention.