### PR TITLE
Windows Credential Store: Use CRED_PERSIST_ENTERPRISE

### DIFF
--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -58,7 +58,7 @@ void WritePasswordJobPrivate::scheduledStart() {
     cred.TargetName = name;
     cred.CredentialBlobSize = data.size();
     cred.CredentialBlob = (LPBYTE)pwd;
-    cred.Persist = CRED_PERSIST_LOCAL_MACHINE;
+    cred.Persist = CRED_PERSIST_ENTERPRISE;
 
     if (!CredWriteW(&cred, 0)) {
         q->emitFinishedWithError( OtherError, tr("Encryption failed") ); //TODO more details available?


### PR DESCRIPTION
Otherwise the credentials are not preserved accross conneciton in a roaming setting

Reported in https://github.com/owncloud/client/issues/6729