### PR TITLE
Fix qmake build on Linux

### DIFF
--- a/qt5keychain.pri
+++ b/qt5keychain.pri
@@ -19,14 +19,37 @@ SOURCES += \
     $$QT5KEYCHAIN_PWD/keychain.cpp
 
 unix:!macx:!ios {
+    # Remove the following LIBSECRET_SUPPORT line
+    # to build without libsecret support.
+    DEFINES += LIBSECRET_SUPPORT
+    contains(DEFINES, LIBSECRET_SUPPORT) {
+        packagesExist(libsecret-1) {
+            !build_pass:message("Libsecret support: on")
+            CONFIG += link_pkgconfig
+            PKGCONFIG += libsecret-1
+            DEFINES += HAVE_LIBSECRET
+        } else {
+            !build_pass:warning("Libsecret not found.")
+            !build_pass:message("Libsecret support: off")
+        }
+    } else {
+        !build_pass:message("Libsecret support: off")
+    }
+
+    # Generate D-Bus interface:
     QT += dbus
+    kwallet_interface.files = $$PWD/org.kde.KWallet.xml
+    DBUS_INTERFACES += kwallet_interface
+
     HEADERS += \
         $$QT5KEYCHAIN_PWD/gnomekeyring_p.h \
-        $$QT5KEYCHAIN_PWD/plaintextstore_p.h
+        $$QT5KEYCHAIN_PWD/plaintextstore_p.h \
+        $$QT5KEYCHAIN_PWD/libsecret_p.h
     SOURCES += \
-        $$QT5KEYCHAIN_PWD/gnomekeyring.cpp \
         $$QT5KEYCHAIN_PWD/keychain_unix.cpp \
-        $$QT5KEYCHAIN_PWD/plaintextstore.cpp
+        $$QT5KEYCHAIN_PWD/plaintextstore.cpp \
+        $$QT5KEYCHAIN_PWD/gnomekeyring.cpp \
+        $$QT5KEYCHAIN_PWD/libsecret.cpp
 }
 
 win32 {
@@ -35,8 +58,10 @@ win32 {
     # instead of the Windows Credential Store.
     DEFINES += USE_CREDENTIAL_STORE
     contains(DEFINES, USE_CREDENTIAL_STORE) {
+        !build_pass:message("Windows Credential Store support: on")
         LIBS += -lAdvapi32
     } else {
+        !build_pass:message("Windows Credential Store support: off")
         LIBS += -lCrypt32
         HEADERS += $$QT5KEYCHAIN_PWD/plaintextstore_p.h
         SOURCES += $$QT5KEYCHAIN_PWD/plaintextstore.cpp


### PR DESCRIPTION
This pull request contains the commit fixing the qmake build on Linux and making the .pro file behavior more close to CMakeLists.txt.

- Fixed build error related to `libsecret`.
- Added `LIBSECRET_SUPPORT` switch.
- Added automatic **KWallet D-Bus Interface** generation.