### PR TITLE
Fix compilation issues when warnings are treated as errors

### DIFF
--- a/gnomekeyring_p.h
+++ b/gnomekeyring_p.h
@@ -45,7 +45,7 @@ public:
         } attributes[32];
     } PasswordSchema;
 
-    typedef void ( *OperationGetStringCallback )( Result result, bool binary,
+    typedef void ( *OperationGetStringCallback )( Result result,
                                                   const char* string, gpointer data );
     typedef void ( *OperationDoneCallback )( Result result, gpointer data );
     typedef void ( *GDestroyNotify )( gpointer data );

--- a/keychain.cpp
+++ b/keychain.cpp
@@ -57,7 +57,7 @@ void Job::doStart() {
 }
 
 void Job::emitFinished() {
-    emit finished( this );
+    Q_EMIT finished( this );
     if ( d->autoDelete )
         deleteLater();
 }

--- a/libsecret.cpp
+++ b/libsecret.cpp
@@ -244,6 +244,9 @@ bool LibSecretKeyring::findPassword(const QString &user, const QString &server,
                                NULL);
     return true;
 #else
+    Q_UNUSED(user)
+    Q_UNUSED(server)
+    Q_UNUSED(self)
     return false;
 #endif
 }
@@ -281,6 +284,12 @@ bool LibSecretKeyring::writePassword(const QString &display_name,
                               NULL);
     return true;
 #else
+    Q_UNUSED(display_name)
+    Q_UNUSED(user)
+    Q_UNUSED(server)
+    Q_UNUSED(mode)
+    Q_UNUSED(password)
+    Q_UNUSED(self)
     return false;
 #endif
 }
@@ -300,6 +309,9 @@ bool LibSecretKeyring::deletePassword(const QString &key, const QString &service
                               NULL);
     return true;
 #else
+    Q_UNUSED(key)
+    Q_UNUSED(service)
+    Q_UNUSED(self)
     return false;
 #endif
 }


### PR DESCRIPTION
When warnings are treated as errors compilation can fail on Linux. This PR fixes that. 
The API change proposed has been checked against gnome API [here](https://developer.gnome.org/gnome-keyring/stable/gnome-keyring-Callbacks.html#GnomeKeyringOperationGetStringCallback) and seems to be sound to me.