### PR TITLE
Search for libsecret with abiversion

### DIFF
--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -54,6 +54,8 @@ static DesktopEnvironment detectDesktopEnvironment() {
         return DesktopEnv_Unity;
     } else if ( xdgCurrentDesktop == "KDE" ) {
         return getKdeVersion();
+    } else if ( xdgCurrentDesktop == "XFCE" ) {
+        return DesktopEnv_Xfce;
     }
 
     QByteArray desktopSession = qgetenv("DESKTOP_SESSION");

--- a/libsecret.cpp
+++ b/libsecret.cpp
@@ -305,7 +305,7 @@ bool LibSecretKeyring::deletePassword(const QString &key, const QString &service
 }
 
 LibSecretKeyring::LibSecretKeyring()
-    : QLibrary("secret-1")
+    : QLibrary(QStringLiteral("secret-1"), 0)
 {
 #ifdef HAVE_LIBSECRET
     if (load()) {


### PR DESCRIPTION
On Debian with a XFCE desktop I see, from strace, that current qtkeychain tries to load libsecret-1.so instead of libsecret-1.so.0. This pull requests fixes that.

This improve/fixes those issues:
#55 , #37,  https://github.com/nextcloud/desktop/issues/883, https://github.com/nextcloud/desktop/issues/990
