### PR TITLE
Convert QStringLiteral to QLatin1String to keep compatibility with Qt4

### DIFF
--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -93,7 +93,7 @@ static bool isKwallet5Available()
     // a wallet can be opened.
 
     iface.setTimeout(500);
-    QDBusMessage reply = iface.call(QStringLiteral("networkWallet"));
+    QDBusMessage reply = iface.call(QLatin1String("networkWallet"));
     return reply.type() == QDBusMessage::ReplyMessage;
 }
 

--- a/libsecret.cpp
+++ b/libsecret.cpp
@@ -305,7 +305,7 @@ bool LibSecretKeyring::deletePassword(const QString &key, const QString &service
 }
 
 LibSecretKeyring::LibSecretKeyring()
-    : QLibrary(QStringLiteral("secret-1"), 0)
+    : QLibrary(QLatin1String("secret-1"), 0)
 {
 #ifdef HAVE_LIBSECRET
     if (load()) {


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Fix #143.