### PR TITLE
build: do not expose libsecret dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if(UNIX AND NOT APPLE AND NOT ANDROID)
             add_definitions(-DHAVE_LIBSECRET=1)
         endif()
         INCLUDE_DIRECTORIES(${LIBSECRET_INCLUDE_DIRS})
-        list(APPEND qtkeychain_LIBRARIES ${LIBSECRET_LIBRARIES})
+        list(APPEND qtkeychain_LIBRARIES_PRIVATE ${LIBSECRET_LIBRARIES})
     endif()
 
     list(APPEND qtkeychain_SOURCES keychain_unix.cpp gnomekeyring.cpp libsecret.cpp plaintextstore.cpp)
@@ -203,7 +203,7 @@ else()
     add_library(${QTKEYCHAIN_TARGET_NAME} STATIC ${qtkeychain_SOURCES} ${qtkeychain_MOC_OUTFILES} ${qtkeychain_QM_FILES})
 endif()
 
-target_link_libraries(${QTKEYCHAIN_TARGET_NAME} PUBLIC ${qtkeychain_LIBRARIES})
+target_link_libraries(${QTKEYCHAIN_TARGET_NAME} PUBLIC ${qtkeychain_LIBRARIES} PRIVATE ${qtkeychain_LIBRARIES_PRIVATE})
 target_include_directories(${QTKEYCHAIN_TARGET_NAME} PUBLIC $<INSTALL_INTERFACE:include/>)
 
 generate_export_header(${QTKEYCHAIN_TARGET_NAME}


### PR DESCRIPTION
We are adding all dependencies to the `PUBLIC` part of [`target_link_libraries`](https://cmake.org/cmake/help/v3.16/command/target_link_libraries.html#libraries-for-a-target-and-or-its-dependents) invocation, which forces all dependent packages to link against it too through `IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE` in `$prefix/lib/cmake/Qt5Keychain/Qt5KeychainLibraryDepends-release.cmake`.

Since it is implementation detail and not a part of the interface, we need to move it to the `PRIVATE` section instead.
