### PR TITLE
Don't use absolute path to frameworks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,11 +140,7 @@ if(APPLE)
         list(APPEND qtkeychain_SOURCES keychain_mac.cpp)
     endif()
 
-    find_library(COREFOUNDATION_LIBRARY CoreFoundation REQUIRED)
-    list(APPEND qtkeychain_LIBRARIES ${COREFOUNDATION_LIBRARY})
-
-    find_library(SECURITY_LIBRARY Security REQUIRED)
-    list(APPEND qtkeychain_LIBRARIES ${SECURITY_LIBRARY})
+    list(APPEND qtkeychain_LIBRARIES "-framework Foundation" "-framework Security")
 endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)


### PR DESCRIPTION
The generated cmake config files where not portable.

Before:
set_target_properties(qt5keychain PROPERTIES
  IMPORTED_LINK_INTERFACE_LIBRARIES_RELWITHDEBINFO "Qt5::Core;/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/CoreFoundation.framework;/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Security.framework"
  IMPORTED_LOCATION_RELWITHDEBINFO "${_IMPORT_PREFIX}/lib/libqt5keychain.0.10.90.dylib"
  IMPORTED_SONAME_RELWITHDEBINFO "/Users/hannah/ownstuff/drone-scripts/macos-64-clang/lib/libqt5keychain.1.dylib"
  )

After:
set_target_properties(qt5keychain PROPERTIES
  IMPORTED_LINK_INTERFACE_LIBRARIES_RELWITHDEBINFO "Qt5::Core;-framework Foundation;-framework Security"
  IMPORTED_LOCATION_RELWITHDEBINFO "${_IMPORT_PREFIX}/lib/libqt5keychain.0.10.90.dylib"
  IMPORTED_SONAME_RELWITHDEBINFO "/Users/hannah/CraftRoot/lib/libqt5keychain.1.dylib"
  )