### PR TITLE
Allow overriding install include path for Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,10 @@ else()
 endif()
 
 target_link_libraries(${QTKEYCHAIN_TARGET_NAME} PUBLIC ${qtkeychain_LIBRARIES})
-target_include_directories(${QTKEYCHAIN_TARGET_NAME} PUBLIC $<INSTALL_INTERFACE:include/>)
+if(NOT INTERFACE_INCLUDE_SUFFIX)
+    set(INTERFACE_INCLUDE_SUFFIX include)
+endif()
+target_include_directories(${QTKEYCHAIN_TARGET_NAME} PUBLIC $<INSTALL_INTERFACE:${INTERFACE_INCLUDE_SUFFIX}/>)
 
 generate_export_header(${QTKEYCHAIN_TARGET_NAME}
   EXPORT_FILE_NAME qkeychain_export.h


### PR DESCRIPTION
When trying to use the package with owncloud-client I noticed cmake complained about non-existent directory… Haiku uses develop/headers/ or even develop/headers/x86 instead of include.