### PR TITLE
Fix: Windows cross build (using qmake)

### DIFF
--- a/qt5keychain.pri
+++ b/qt5keychain.pri
@@ -59,10 +59,10 @@ win32 {
     DEFINES += USE_CREDENTIAL_STORE
     contains(DEFINES, USE_CREDENTIAL_STORE) {
         !build_pass:message("Windows Credential Store support: on")
-        LIBS += -lAdvapi32
+        LIBS += -ladvapi32
     } else {
         !build_pass:message("Windows Credential Store support: off")
-        LIBS += -lCrypt32
+        LIBS += -lcrypt32
         HEADERS += $$QT5KEYCHAIN_PWD/plaintextstore_p.h
         SOURCES += $$QT5KEYCHAIN_PWD/plaintextstore.cpp
     }


### PR DESCRIPTION
This change fixes cross building from Linux to Windows when using the
mingw tool chain. Using capital library names breaks the build on Linux
(whereas for Windows it should not matter, as file names are case
insensitive there).