### PR TITLE
*.cmake.in: Make sure find_dependency() is defined

### DIFF
--- a/QtKeychainConfig.cmake.in
+++ b/QtKeychainConfig.cmake.in
@@ -7,6 +7,7 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/Qt@QTKEYCHAIN_VERSION_INFIX@KeychainLibraryDepends.cmake")
 
+include(CMakeFindDependencyMacro)
 
 if("@QTKEYCHAIN_VERSION_INFIX@" STREQUAL "5")
     find_dependency(Qt5Core)


### PR DESCRIPTION
The commit f39305c8 that switches from ECMPackageConfigHelpers to
CMakePackageConfigHelpers has broken integration with Qt5Keychain
from CMake-based projects, with find_package(Qt5Keychain) leading
to a message like:
```
CMake Error at install/lib/cmake/Qt5Keychain/Qt5KeychainConfig.cmake:36 (find_dependency):
  Unknown CMake command "find_dependency".
```
Apparently, the find_dependency() macro definition was inserted
in QtKeychainConfig.cmake by ECM machinery before. Including
the respective definition from the CMake library fixes the problem.