### PR TITLE
QMake: Add missing KEYCHAIN_DBUS define

### DIFF
--- a/qt5keychain.pri
+++ b/qt5keychain.pri
@@ -41,6 +41,7 @@ unix:!android:!macx:!ios {
     }
 
     # Generate D-Bus interface:
+    DEFINES += KEYCHAIN_DBUS
     QT += dbus
     kwallet_interface.files = $$PWD/org.kde.KWallet.xml
     DBUS_INTERFACES += kwallet_interface


### PR DESCRIPTION
Fixes #182