### PR TITLE
Use CFRelease on Apple Platforms

### DIFF
--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -89,7 +89,7 @@ void ReadPasswordJobPrivate::scheduledStart()
     }
 
     if (dataRef)
-        [dataRef release];
+        CFRelease(dataRef);
 }
 
 void WritePasswordJobPrivate::scheduledStart()


### PR DESCRIPTION
This change switches to using `CFRelease` instead of calling the `release()` method on the `CFTypeRef` in the Apple backend.

Background: I migrated my app where I use QtKeychain to use `cmake` also for iOS. This seems - maybe due to slightly different compiler flags? - to have triggered an issue: During compilation I got errors in the changed line, telling about an invalid receiver on that method.

Using `CFRelease` instead of the `release()` method, the build worked like a charm.

I am definitely no expert on native iOS APIs nor Objective-C/C++, but according to some Apple docs, I would even think using `CFRelease` is the preferred method:

- https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-CJBEJBHH
- https://developer.apple.com/documentation/corefoundation/1521153-cfrelease
- And especially https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/working_with_core_foundation_types.

The last document has the following paragraph:

> You can also invoke the retain(), release(), and autorelease() methods on unmanaged objects, but this approach is not recommended.

So I think that using `CFRelease` might be the preferred method to release the reference anyway. But then again, I am definitely not an expert on that topic 😉 
