### PR TITLE
Don't find QtDBus on Android

### DIFF
--- a/QtKeychainConfig.cmake.in
+++ b/QtKeychainConfig.cmake.in
@@ -14,7 +14,7 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Qt@QTKEYCHAIN_VERSION_INFIX@Core)
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT ANDROID)
     find_dependency(Qt@QTKEYCHAIN_VERSION_INFIX@DBus)
 endif()
 


### PR DESCRIPTION
Android is Unix, but we don't want DBus there