### PR TITLE
Raise the minimum CMake version to match the Qt 6 one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.16)
 
 set(QTKEYCHAIN_VERSION 0.12.90)
 set(QTKEYCHAIN_SOVERSION 1)


### PR DESCRIPTION
Qt 6.3 wants the dependent projects to use the same CMake policies
as the ones used to build Qt. To do that, an error is thrown if
the minimum CMake version doesn't match the qtbase one on platforms
using shared libraries.