### PR TITLE
Updated deprecated annotations

### DIFF
--- a/org.kde.KWallet.xml
+++ b/org.kde.KWallet.xml
@@ -156,7 +156,7 @@
     </method>
     <method name="readEntryList">
       <arg type="a{sv}" direction="out"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg name="handle" type="i" direction="in"/>
       <arg name="folder" type="s" direction="in"/>
       <arg name="key" type="s" direction="in"/>
@@ -164,7 +164,7 @@
     </method>
     <method name="readMapList">
       <arg type="a{sv}" direction="out"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg name="handle" type="i" direction="in"/>
       <arg name="folder" type="s" direction="in"/>
       <arg name="key" type="s" direction="in"/>
@@ -172,7 +172,7 @@
     </method>
     <method name="readPasswordList">
       <arg type="a{sv}" direction="out"/>
-      <annotation name="com.trolltech.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
       <arg name="handle" type="i" direction="in"/>
       <arg name="folder" type="s" direction="in"/>
       <arg name="key" type="s" direction="in"/>


### PR DESCRIPTION
I've had a look at both #150 and #172 - while one comment in the latter suggests changing more things, here I just want to get rid of this warning which after updating does not seem to introduce any regressions and the warning itself is gone.

Fixes #150
