### PR TITLE
Prevent race on applications quitting whilst save jobs are in process

### DIFF
--- a/keychain_p.h
+++ b/keychain_p.h
@@ -14,6 +14,7 @@
 #include <QPointer>
 #include <QSettings>
 #include <QQueue>
+#include <QEventLoopLocker>
 
 #if defined(KEYCHAIN_DBUS)
 
@@ -79,6 +80,9 @@ protected:
     bool insecureFallback;
     QPointer<QSettings> settings;
     QString key;
+
+private:
+    QEventLoopLocker lock;
 
 friend class Job;
 friend class JobExecutor;


### PR DESCRIPTION
If an application calls quit or closes all windows we still want to finish saving the password. Qt provides a mechanism to defer the exit whilst jobs are active.

This brings us in line with KDE's KJob.

Note this change can cause a niche behavioural change with QCoreApplication applications that incorrectly have with quit loop enabled and use the main event loop so should probably not be backported.