### PR TITLE
Compile with Qt 6.4

### DIFF
--- a/keychain_android.cpp
+++ b/keychain_android.cpp
@@ -105,8 +105,10 @@ void WritePasswordJobPrivate::scheduledStart()
         const KeyPairGeneratorSpec spec =
             #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
                 KeyPairGeneratorSpec::Builder(Context(QtAndroid::androidActivity())).
-            #else
+            #elif QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
                 KeyPairGeneratorSpec::Builder(QNativeInterface::QAndroidApplication::context()).
+            #else
+                KeyPairGeneratorSpec::Builder((jobject)QNativeInterface::QAndroidApplication::context()).
             #endif
                 setAlias(alias).
                 setSubject(X500Principal(QStringLiteral("CN=QtKeychain, O=Android Authority"))).


### PR DESCRIPTION
The return type of QAndroidApplication::context() changed.