### PR TITLE
.gitignore ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ qtkeychain.build
 *.sw?
 
 /build-*/
+/compile_commands.json


### PR DESCRIPTION
The file compile_commands.json is generated by default when building using kdesrc-build. kdesrc-build passes to CMake by default the option "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON".

If the file ignore compile_commands.json is not ignored, when building using kdesrc-build, there are unstaged changes in the local git clone/working directory.