### PR TITLE
Fix freezing with Apple keychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,8 +274,22 @@ install(TARGETS ${QTKEYCHAIN_TARGET_NAME}
 )
 
 if(BUILD_TEST_APPLICATION)
+    set( testclient_LIBRARIES ${QTKEYCHAIN_TARGET_NAME} )
+
+    if(APPLE)
+        list(APPEND testclient_LIBRARIES "-framework Cocoa")
+
+        if (BUILD_WITH_QT6)
+            find_package(Qt6 COMPONENTS Gui REQUIRED)
+            list(APPEND testclient_LIBRARIES Qt6::Gui)
+        else()
+            find_package(Qt5 COMPONENTS Gui REQUIRED)
+            list(APPEND testclient_LIBRARIES Qt5::Gui)
+        endif()
+
+    endif()
     add_executable( testclient testclient.cpp )
-    target_link_libraries( testclient ${QTKEYCHAIN_TARGET_NAME})
+    target_link_libraries( testclient ${testclient_LIBRARIES})
 endif()
 
 

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -223,18 +223,23 @@ static void StartReadPassword(const QString &service, const QString &key, const 
         if (status == errSecSuccess) {
             const CFDataRef castedDataRef = (CFDataRef)dataRef;
             NSData * const data = (__bridge NSData *)castedDataRef;
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainReadTaskFinished
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoDataKey: data,
-                                                                        KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainReadTaskFinished
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoDataKey: data,
+                                                                            KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
         } else {
             NSNumber * const statusNumber = [NSNumber numberWithInt:status];
             NSString * const descriptiveErrorString = @"Could not retrieve private key from keystore";
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
-                                                                        KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
-                                                                        KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
+                                                                            KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
+                                                                            KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
+
             if (dataRef) {
                 CFRelease(dataRef);
             }
@@ -273,17 +278,22 @@ static void StartWritePassword(const QString &service, const QString &key, const
         }
 
         if (status == errSecSuccess) {
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinished
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinished
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
         } else {
             NSNumber * const statusNumber = [NSNumber numberWithInt:status];
             NSString * const descriptiveErrorString = @"Could not store data in settings";
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
-                                                                        KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
-                                                                        KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
+                                                                            KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
+                                                                            KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
         }
     });
 }
@@ -302,17 +312,21 @@ static void StartDeletePassword(const QString &service, const QString &key, cons
         const OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
 
         if (status == errSecSuccess) {
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinished
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinished
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
         } else {
             NSNumber * const statusNumber = [NSNumber numberWithInt:status];
             NSString * const descriptiveErrorString = @"Could not remove private key from keystore";
-            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
-                                                              object:nil
-                                                            userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
-                                                                        KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
-                                                                        KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
+                                                                  object:nil
+                                                                userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
+                                                                            KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
+                                                                            KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
+            });
         }
     });
 }

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -73,11 +73,15 @@ struct ErrorDescription
 
 @interface AppleKeychainInterface : NSObject
 
-@property (readonly) Job *job;
-@property (readonly) JobPrivate *privateJob;
-
 - (instancetype)initWithJob:(Job *)job andPrivateJob:(JobPrivate *)privateJob;
 
+@end
+
+@interface AppleKeychainInterface()
+{
+    QPointer<Job> _job;
+    QPointer<JobPrivate> _privateJob;
+}
 @end
 
 @implementation AppleKeychainInterface
@@ -114,7 +118,10 @@ struct ErrorDescription
 
 - (void)keychainTaskFinished:(NSNotification *)notification
 {
-    _job->emitFinished();
+    if (_job) {
+        _job->emitFinished();
+    }
+
     [self release];
 }
 
@@ -129,7 +136,9 @@ struct ErrorDescription
 
     NSData * const retrievedData = (NSData *)[userInfo objectForKey:KeychainNotificationUserInfoDataKey];
     if (retrievedData != nil) {
-        _privateJob->data = QByteArray::fromNSData(retrievedData);
+        if (_privateJob) {
+            _privateJob->data = QByteArray::fromNSData(retrievedData);
+        }
 
         const CFDataRef dataRef = (__bridge CFDataRef)retrievedData;
         if (dataRef) {
@@ -137,7 +146,10 @@ struct ErrorDescription
         }
     }
 
-    _job->emitFinished();
+    if (_job) {
+        _job->emitFinished();
+    }
+
     [self release];
 }
 
@@ -157,7 +169,10 @@ struct ErrorDescription
     const ErrorDescription error = ErrorDescription::fromStatus(status);
     const auto fullMessage = localisedDescriptiveMessage.isEmpty() ? error.message : QStringLiteral("%1: %2").arg(localisedDescriptiveMessage, error.message);
 
-    _job->emitFinishedWithError(error.code, fullMessage);
+    if (_job) {
+        _job->emitFinishedWithError(error.code, fullMessage);
+    }
+
     [self release];
 }
 

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -239,6 +239,30 @@ static void StartWritePassword(const QString &service, const QString &key, const
     });
 }
 
+static void StartDeletePassword(const QString &service, const QString &key)
+{
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+        NSDictionary * const query = @{
+            (__bridge NSString *)kSecClass: (__bridge NSString *)kSecClassGenericPassword,
+            (__bridge NSString *)kSecAttrService: service.toNSString(),
+            (__bridge NSString *)kSecAttrAccount: key.toNSString(),
+        };
+
+        const OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+
+        if (status == errSecSuccess) {
+            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinished object:nil];
+        } else {
+            NSNumber * const statusNumber = [NSNumber numberWithInt:status];
+            NSString * const descriptiveErrorString = @"Could not remove private key from keystore";
+            [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainTaskFinishedWithError
+                                                              object:nil
+                                                            userInfo:@{ KeychainNotificationUserInfoStatusKey: statusNumber,
+                                                                        KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString }];
+        }
+    });
+}
+
 void ReadPasswordJobPrivate::scheduledStart()
 {
     [[AppleKeychainInterface alloc] initWithJob:q andPrivateJob:this];
@@ -253,20 +277,6 @@ void WritePasswordJobPrivate::scheduledStart()
 
 void DeletePasswordJobPrivate::scheduledStart()
 {
-    const NSDictionary *const query = @{
-            (__bridge id) kSecClass: (__bridge id) kSecClassGenericPassword,
-            (__bridge id) kSecAttrService: (__bridge NSString *) service.toCFString(),
-            (__bridge id) kSecAttrAccount: (__bridge NSString *) key.toCFString(),
-    };
-
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        const OSStatus status = SecItemDelete((__bridge CFDictionaryRef) query);
-
-        if (status == errSecSuccess) {
-            q->emitFinished();
-        } else {
-            const ErrorDescription error = ErrorDescription::fromStatus(status);
-            q->emitFinishedWithError(error.code, Job::tr("Could not remove private key from keystore: %1").arg(error.message));
-        }
-    });
+    [[AppleKeychainInterface alloc] initWithJob:q andPrivateJob:this];
+    StartDeletePassword(service, key);
 }

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -115,6 +115,7 @@ struct ErrorDescription
 - (void)keychainTaskFinished:(NSNotification *)notification
 {
     _job->emitFinished();
+    [self release];
 }
 
 - (void)keychainReadTaskFinished:(NSNotification *)notification
@@ -129,9 +130,15 @@ struct ErrorDescription
     NSData * const retrievedData = (NSData *)[userInfo objectForKey:KeychainNotificationUserInfoDataKey];
     if (retrievedData != nil) {
         _privateJob->data = QByteArray::fromNSData(retrievedData);
+
+        const CFDataRef dataRef = (__bridge CFDataRef)retrievedData;
+        if (dataRef) {
+            CFRelease(dataRef);
+        }
     }
 
     _job->emitFinished();
+    [self release];
 }
 
 - (void)keychainTaskFinishedWithError:(NSNotification *)notification
@@ -151,6 +158,7 @@ struct ErrorDescription
     const auto fullMessage = localisedDescriptiveMessage.isEmpty() ? error.message : QStringLiteral("%1: %2").arg(localisedDescriptiveMessage, error.message);
 
     _job->emitFinishedWithError(error.code, fullMessage);
+    [self release];
 }
 
 @end

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -160,11 +160,6 @@ struct ErrorDescription
         if (_privateJob) {
             _privateJob->data = QByteArray::fromNSData(retrievedData);
         }
-
-        const CFDataRef dataRef = (__bridge CFDataRef)retrievedData;
-        if (dataRef) {
-            CFRelease(dataRef);
-        }
     }
 
     if (_job) {
@@ -222,7 +217,7 @@ static void StartReadPassword(const QString &service, const QString &key, const 
 
         if (status == errSecSuccess) {
             const CFDataRef castedDataRef = (CFDataRef)dataRef;
-            NSData * const data = (__bridge NSData *)castedDataRef;
+            NSData * const data = [NSData dataWithBytes:CFDataGetBytePtr(castedDataRef) length:CFDataGetLength(castedDataRef)];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [NSNotificationCenter.defaultCenter postNotificationName:AppleKeychainReadTaskFinished
                                                                   object:nil
@@ -239,11 +234,11 @@ static void StartReadPassword(const QString &service, const QString &key, const 
                                                                             KeychainNotificationUserInfoDescriptiveErrorKey: descriptiveErrorString,
                                                                             KeychainNotificationUserInfoNotificationId: notificationIdNumber }];
             });
-
-            if (dataRef) {
-                CFRelease(dataRef);
-            }
         }
+
+         if (dataRef) {
+             CFRelease(dataRef);
+         }
     });
 }
 

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -14,6 +14,28 @@
 
 using namespace QKeychain;
 
+@interface AppleKeychainInterface : NSObject
+
+@property (readonly) JobPrivate *ownerJob;
+
+- (instancetype)initWithOwner:(JobPrivate *)ownerJob;
+
+@end
+
+@implementation AppleKeychainInterface
+
+- (instancetype)initWithOwner:(JobPrivate *)ownerJob
+{
+    self = [super init];
+    if (self) {
+        _ownerJob = ownerJob;
+    }
+    return self;
+}
+
+@end
+
+
 struct ErrorDescription
 {
     QKeychain::Error code;

--- a/testclient.cpp
+++ b/testclient.cpp
@@ -6,7 +6,14 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. For licensing and distribution        *
  * details, check the accompanying file 'COPYING'.                            *
  *****************************************************************************/
+
+#include <QtGlobal>
+#ifdef Q_OS_DARWIN
+#include <QGuiApplication>
+#else
 #include <QCoreApplication>
+#endif
+
 #include <QStringList>
 
 #include "keychain.h"
@@ -22,7 +29,14 @@ static int printUsage() {
 }
 
 int main( int argc, char** argv ) {
+#ifdef Q_OS_DARWIN
+    // Since we use NSNotificationCenter under the hood in keychain_apple,
+    // we use QGuiApplication to automatically configure the platform
+    // integration stuff done in this class and not in QCoreApplication
+    QGuiApplication app( argc, argv );
+#else
     QCoreApplication app( argc, argv );
+#endif
     const QStringList args = app.arguments();
     if ( args.count() < 2 )
         return printUsage();


### PR DESCRIPTION
SecItemCopyMatching, SecItemUpdate, and SecItemDelete all block the thread they are run on. This means that on Apple devices there is a possibility for QtKeychain to cause a freeze on the application main thread.

Per Apple's documentation, this PR wraps the work done on keychain retrieval with `dispatch_async` on `DISPATCH_QUEUE_PRIORITY_BACKGROUND`

Documentation links:
https://developer.apple.com/documentation/security/1398306-secitemcopymatching?language=objc https://developer.apple.com/documentation/security/1393617-secitemupdate?language=objc https://developer.apple.com/documentation/security/1395547-secitemdelete?language=objc