### PR TITLE
Add API to check whether a secure backend is available at all

### DIFF
--- a/keychain.h
+++ b/keychain.h
@@ -266,6 +266,17 @@ private:
     friend class QKeychain::DeletePasswordJobPrivate;
 };
 
+/**
+ * Checks whether there is a viable secure backend available.
+ * This particularly matters on UNIX platforms where multiple different backends
+ * exist and none might be available.
+ *
+ * Note that using the insecure fallback will work even if no secure backend is available.
+ *
+ * @since 0.14.0
+ */
+bool isAvailable();
+
 } // namespace QtKeychain
 
 #endif

--- a/keychain_android.cpp
+++ b/keychain_android.cpp
@@ -188,3 +188,8 @@ void DeletePasswordJobPrivate::scheduledStart()
     else
         q->emitFinished();
 }
+
+bool isAvailable()
+{
+    return true;
+}

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -256,3 +256,8 @@ void DeletePasswordJobPrivate::scheduledStart()
     AppleKeychainInterface * const interface = [[AppleKeychainInterface alloc] initWithJob:q andPrivateJob:this];
     StartDeletePassword(service, key, interface);
 }
+
+bool isAvailable()
+{
+    return true;
+}

--- a/keychain_haiku.cpp
+++ b/keychain_haiku.cpp
@@ -185,3 +185,8 @@ void DeletePasswordJobPrivate::scheduledStart()
 
     q->emitFinishedWithError( error, errorString );
 }
+
+bool isAvailable()
+{
+    return true;
+}

--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -588,3 +588,8 @@ void DeletePasswordJobPrivate::fallbackOnError(const QDBusError &err) {
 
     q->emitFinished();
 }
+
+bool isAvailable()
+{
+    return LibSecretKeyring::isAvailable() || GnomeKeyring::isAvailable() || isKwallet5Available();
+}

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -186,3 +186,8 @@ void DeletePasswordJobPrivate::scheduledStart() {
     }
 }
 #endif
+
+bool isAvailable()
+{
+    return true;
+}


### PR DESCRIPTION
Particularly important on Unix, where there are multiple options and neither of them is guaranteed.

Fixes #224.