### PR TITLE
Export QKeychain::isAvailable() to make it usable in a shared build

### DIFF
--- a/keychain.h
+++ b/keychain.h
@@ -275,7 +275,7 @@ private:
  *
  * @since 0.14.0
  */
-bool isAvailable();
+QKEYCHAIN_EXPORT bool isAvailable();
 
 } // namespace QtKeychain
 

--- a/keychain_android.cpp
+++ b/keychain_android.cpp
@@ -189,7 +189,7 @@ void DeletePasswordJobPrivate::scheduledStart()
         q->emitFinished();
 }
 
-bool isAvailable()
+bool QKeychain::isAvailable()
 {
     return true;
 }

--- a/keychain_apple.mm
+++ b/keychain_apple.mm
@@ -257,7 +257,7 @@ void DeletePasswordJobPrivate::scheduledStart()
     StartDeletePassword(service, key, interface);
 }
 
-bool isAvailable()
+bool QKeychain::isAvailable()
 {
     return true;
 }

--- a/keychain_haiku.cpp
+++ b/keychain_haiku.cpp
@@ -186,7 +186,7 @@ void DeletePasswordJobPrivate::scheduledStart()
     q->emitFinishedWithError( error, errorString );
 }
 
-bool isAvailable()
+bool QKeychain::isAvailable()
 {
     return true;
 }

--- a/keychain_unix.cpp
+++ b/keychain_unix.cpp
@@ -589,7 +589,7 @@ void DeletePasswordJobPrivate::fallbackOnError(const QDBusError &err) {
     q->emitFinished();
 }
 
-bool isAvailable()
+bool QKeychain::isAvailable()
 {
     return LibSecretKeyring::isAvailable() || GnomeKeyring::isAvailable() || isKwallet5Available();
 }

--- a/keychain_win.cpp
+++ b/keychain_win.cpp
@@ -187,7 +187,7 @@ void DeletePasswordJobPrivate::scheduledStart() {
 }
 #endif
 
-bool isAvailable()
+bool QKeychain::isAvailable()
 {
     return true;
 }


### PR DESCRIPTION
Also, the definitions needs to be fully qualified, otherwise this is producing symbols in the top-level namespace instead.