### PR TITLE
Fix build with Qt 6.7 on Android

### DIFF
--- a/keychain_android.cpp
+++ b/keychain_android.cpp
@@ -107,8 +107,10 @@ void WritePasswordJobPrivate::scheduledStart()
                 KeyPairGeneratorSpec::Builder(Context(QtAndroid::androidActivity())).
             #elif QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
                 KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context())).
-            #else
+            #elif QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
                 KeyPairGeneratorSpec::Builder(Context((jobject)QNativeInterface::QAndroidApplication::context())).
+            #else
+                KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context().object<jobject>())).
             #endif
                 setAlias(alias).
                 setSubject(X500Principal(QStringLiteral("CN=QtKeychain, O=Android Authority"))).


### PR DESCRIPTION
QNativeInterface::QAndroidApplication::context() changed its return type.