### PR TITLE
Fix jobject cast

### DIFF
--- a/qtkeychain/keychain_android.cpp
+++ b/qtkeychain/keychain_android.cpp
@@ -107,6 +107,8 @@ void WritePasswordJobPrivate::scheduledStart()
                 KeyPairGeneratorSpec::Builder(Context(QtAndroid::androidActivity())).
             #elif QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
                 KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context())).
+            #elif QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+                KeyPairGeneratorSpec::Builder(Context((jobject)QNativeInterface::QAndroidApplication::context())).
             #else
                 KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context().object())).
             #endif

--- a/qtkeychain/keychain_android.cpp
+++ b/qtkeychain/keychain_android.cpp
@@ -108,7 +108,7 @@ void WritePasswordJobPrivate::scheduledStart()
             #elif QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
                 KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context())).
             #else
-                KeyPairGeneratorSpec::Builder(Context((jobject)QNativeInterface::QAndroidApplication::context())).
+                KeyPairGeneratorSpec::Builder(Context(QNativeInterface::QAndroidApplication::context().object())).
             #endif
                 setAlias(alias).
                 setSubject(X500Principal(QStringLiteral("CN=QtKeychain, O=Android Authority"))).


### PR DESCRIPTION
Currently, targeting Android with Qt 6.7.1 results in the following error
```
/home/nep/Projects/qtkeychain/qtkeychain/keychain_android.cpp:111:55: error: cannot cast from type 'QtJniTypes::Context' to pointer type 'jobject' (aka '_jobject *')
                KeyPairGeneratorSpec::Builder(Context((jobject)QNativeInterface::QAndroidApplication::context())).
                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
That error (and this patch) is consistent with the Qt documentation:
https://doc.qt.io/qt-6/qnativeinterface-qandroidapplication.html#context
https://doc.qt.io/qt-6/qjniobject.html#object

~~Considering [that API was already how it is as far back as 6.4.0](https://github.com/qt/qtbase/commit/367092d7e02bfe0054b78e856b7addbdb56aae2e), I am not sure how this code ever worked (perhaps deprecation? not sure how Qt handles that), insight would be appreciated.~~