### PR TITLE
Fix translation creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,14 @@ add_subdirectory(qtkeychain)
 ### Translations
 ###
 
+set(qtkeychain_TR_FILES
+      translations/qtkeychain_de.ts
+      translations/qtkeychain_fr.ts
+      translations/qtkeychain_ro.ts
+      translations/qtkeychain_ru.ts
+      translations/qtkeychain_zh.ts
+)
+
 file(GLOB qtkeychain_TR_SOURCES qtkeychain/*.cpp qtkeychain/*.h qtkeychain/*.ui)
 if ( BUILD_TRANSLATIONS )
     qt_create_translation(qtkeychain_MESSAGES ${qtkeychain_TR_SOURCES} ${qtkeychain_TR_FILES})

--- a/qtkeychain/CMakeLists.txt
+++ b/qtkeychain/CMakeLists.txt
@@ -67,14 +67,6 @@ endif()
 
 QT_WRAP_CPP(qtkeychain_MOC_OUTFILES keychain.h keychain_p.h gnomekeyring_p.h)
 
-set(qtkeychain_TR_FILES
-      translations/qtkeychain_de.ts
-      translations/qtkeychain_fr.ts
-      translations/qtkeychain_ro.ts
-      translations/qtkeychain_ru.ts
-      translations/qtkeychain_zh.ts
-)
-
 add_library(${QTKEYCHAIN_TARGET_NAME} ${qtkeychain_SOURCES} ${qtkeychain_MOC_OUTFILES} ${qtkeychain_QM_FILES})
 if(WIN32)
     set_target_properties( ${QTKEYCHAIN_TARGET_NAME} PROPERTIES DEBUG_POSTFIX "d" )


### PR DESCRIPTION
22bac419 inadvertandly moved the qtkeychain_TR_FILES variable creation to the qtkeychain subfolder. It has to be created before qt_create_translation gets used.