### PR TITLE
Fix Qt 5 build on Windows and silence warnings on clang-cl

### DIFF
--- a/qtkeychain/CMakeLists.txt
+++ b/qtkeychain/CMakeLists.txt
@@ -6,7 +6,7 @@ set(qtkeychain_SOURCES
     keychain.h
 )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+if(MSVC)
     # CMake < 3.15 sneaks in /W# flags for us, so we need a replacement,
     # or we'll get a warning (cf. CMP0092)
     if (CMAKE_CXX_FLAGS MATCHES "/W[0-4]")

--- a/qtkeychain/CMakeLists.txt
+++ b/qtkeychain/CMakeLists.txt
@@ -29,6 +29,9 @@ if(WIN32)
     if(MINGW)
         add_definitions( -O2 )
     endif()
+
+    set(CMAKE_CXX_STANDARD 17)
+    add_definitions( /utf-8 -DUNICODE )
 endif()
 
 if(APPLE)

--- a/qtkeychain/keychain_win.cpp
+++ b/qtkeychain/keychain_win.cpp
@@ -25,7 +25,7 @@ namespace {
 
     constexpr quint64 MAX_ATTRIBUTE_SIZE = 256;
     constexpr quint64 MAX_ATTRIBUTE_COUNT =  64;
-    constexpr quint64 MAX_BLOB_SIZE = CRED_MAX_CREDENTIAL_BLOB_SIZE + MAX_ATTRIBUTE_SIZE * MAX_ATTRIBUTE_COUNT;
+    constexpr qsizetype MAX_BLOB_SIZE = CRED_MAX_CREDENTIAL_BLOB_SIZE + MAX_ATTRIBUTE_SIZE * MAX_ATTRIBUTE_COUNT;
 
     QString formatWinError(ulong errorCode)
     {
@@ -181,7 +181,7 @@ void WritePasswordJobPrivate::scheduledStart() {
         quint64 pos = 0;
         auto read = [&buffer, &pos](const quint64 size, auto &dest, auto &sizeOut)
         {
-            dest = reinterpret_cast<std::remove_reference<decltype(dest)>::type>(buffer.data()) + pos;
+            dest = reinterpret_cast<typename std::remove_reference<decltype(dest)>::type>(buffer.data()) + pos;
             sizeOut = std::min<ulong>(size, buffer.size() - pos);
             pos += sizeOut;
         };
@@ -206,7 +206,7 @@ void WritePasswordJobPrivate::scheduledStart() {
     // Unfortunately these error codes aren't documented.
     // Found empirically on Win10 1803 build 17134.523.
     if (err == RPC_S_INVALID_BOUND) {
-        const size_t maxTargetName = CRED_MAX_GENERIC_TARGET_NAME_LENGTH;
+        const QString::size_type maxTargetName = CRED_MAX_GENERIC_TARGET_NAME_LENGTH;
         if (key.size() > maxTargetName) {
             q->emitFinishedWithError(
                 OtherError,


### PR DESCRIPTION
- On `clang-cl`, `-Wall` is equivalent to `-Weverything` (so this enables _all_ warnings - which we don't want). `/W4` is still supported (`MSVC` matches both MSVC and clang-cl).
- With `/W4` clang-cl showed some comparison warnings and a warning about C++ 20 compatibility (missing `typename`)
- Building with Qt 5 wasn't supported, because the standard was too low and Unicode wasn't enabled (`TCHAR` was a `char` instead of a `wchar_t`).