### PR TITLE
Fix read password job on Haiku

### DIFF
--- a/qtkeychain/keychain_haiku.cpp
+++ b/qtkeychain/keychain_haiku.cpp
@@ -86,7 +86,7 @@ void ReadPasswordJobPrivate::scheduledStart()
                                       q->key().toUtf8().constData(),
                                       false, password);
 
-    data = QByteArray(reinterpret_cast<const char*>(password.Data()), password.DataLength());
+    data = QByteArray(reinterpret_cast<const char*>(password.Data()));
 
     switch ( result ) {
     case B_OK:


### PR DESCRIPTION
There seems to be a breaking change in how QString::fromUtf8 works in Qt6, and this affects QtKeychain handling on Haiku. If we use QByteArray with an explicit size, it messes with the null termination handling and the application is given a QString with a null terminator, which fails.

But this actually isn't needed at all, letting QByteArray figure out where the password data ends is good enough and lets Qt6 applications work again on Haiku.

@Begasus