### PR TITLE
Include cmath for std::ceil

### DIFF
--- a/qtkeychain/keychain_win.cpp
+++ b/qtkeychain/keychain_win.cpp
@@ -14,6 +14,7 @@
 #include <wincred.h>
 #include <wincrypt.h>
 
+#include <cmath>
 #include <memory>
 
 using namespace QKeychain;


### PR DESCRIPTION
This fixes the following compiler error with mingw g++
keychain_win.cpp:190:36: error: 'ceil' is not a member of 'std'