### PR TITLE
Fix build with BUILD_TESTING=ON, don't rely on QT_MAJOR_VERSION

### DIFF
--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -1,6 +1,10 @@
 include(ECMAddTests)
 
-find_package(Qt${QT_MAJOR_VERSION} COMPONENTS Test REQUIRED)
+if (BUILD_WITH_QT6)
+    find_package(Qt6 CONFIG COMPONENTS Test REQUIRED)
+else()
+    find_package(Qt5 CONFIG COMPONENTS Test REQUIRED)
+endif()
 
 ecm_add_tests(basic.cpp LINK_LIBRARIES ${QTKEYCHAIN_TARGET_NAME} Qt${QT_MAJOR_VERSION}::Test)
 set_property(TARGET basic PROPERTY AUTOMOC ON)


### PR DESCRIPTION
CMake Error at 3rdparty/qtkeychain/autotest/CMakeLists.txt:3 (find_package):
  By not providing "FindQt.cmake" in CMAKE_MODULE_PATH this project has asked [...]

Two problems there:
- QT_MAJOR_VERSION isn't set, so don't rely on it, use BUILD_WITH_QT6 like the parent CMakeLists.txt
- There's no FindQt, FindQt5 or FindQt6, so add CONFIG so that cmake only warns about Qt5Config.cmake/Qt6Config.cmake not found