### PR TITLE
Fix the crash caused by timeout when reading or writing keychain on macOS

### DIFF
--- a/qtkeychain/keychain_apple.mm
+++ b/qtkeychain/keychain_apple.mm
@@ -122,11 +122,10 @@ struct ErrorDescription
 
 - (void)keychainReadTaskFinished:(NSData *)retrievedData
 {
-    _privateJob->data.clear();
-    _privateJob->mode = JobPrivate::Binary;
-
-    if (retrievedData != nil) {
-        if (_privateJob) {
+    if (_privateJob) {
+        _privateJob->data.clear();
+        _privateJob->mode = JobPrivate::Binary;
+        if (retrievedData != nil) {
             _privateJob->data = QByteArray::fromNSData(retrievedData);
         }
     }


### PR DESCRIPTION

Reproduction method: Enter the password when reading or writing the keychain for the first time. 
If the input is slow and causes the read or write timeout, the application will crash.