### PR TITLE
windows: store key@service if a non empty key is given

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ if (WIN32)
     if (USE_CREDENTIAL_STORE)
         add_definitions(-DUSE_CREDENTIAL_STORE=1)
     endif()
+
+    option(USE_COMPAT_NAMING_SCHEME "store entries without the service name" OFF)
+    if (USE_COMPAT_NAMING_SCHEME)
+        add_definitions(-DUSE_COMPAT_NAMING_SCHEME=1)
+    endif()
 endif()
 
 if(BUILD_WITH_QT5)

--- a/qtkeychain/keychain.h
+++ b/qtkeychain/keychain.h
@@ -43,6 +43,18 @@ class JobPrivate;
 
 /**
  * @brief Abstract base class for all QKeychain jobs.
+ *
+ * @bug on windows up to 0.15.0 the credentials were erroneously stored without the @p service
+ *      name attached and could have overwritten credentials of other applications if they used
+ *      the same @p key argument.
+ *      While this has been fixed, existing applications need to take this into account and the
+ *      following migration strategies exist:
+ *        - The CMake compile time option -DUSE_COMPAT_NAMING_SCHEME=ON will compile in the old
+ *          behavior
+ *        - The application specific setting 'qtkeychainCompatNamingScheme' will enable old
+ *          behavior if set (system or user settings of the application)
+ *        - The application specific setting 'qtkeychainFallbackToCompatNamingScheme' will
+ *          add a fallback on credential read if no new entry exists (@p EntryNotFound returned)
  */
 class QKEYCHAIN_EXPORT Job : public QObject
 {

--- a/qtkeychain/keychain_win.cpp
+++ b/qtkeychain/keychain_win.cpp
@@ -29,17 +29,40 @@ constexpr quint64 MAX_ATTRIBUTE_COUNT = 64;
 constexpr qsizetype MAX_BLOB_SIZE =
         CRED_MAX_CREDENTIAL_BLOB_SIZE + MAX_ATTRIBUTE_SIZE * MAX_ATTRIBUTE_COUNT;
 
-static QString targetName(const QString& service, const QString& key) {
+static bool useCompatNamingScheme() {
 #if defined(USE_COMPAT_NAMING_SCHEME)
-    Q_UNUSED(service)
-    return key;
+	return true;
 #else
+    /* QSettings by default are instanciated with calling process
+     * QCoreApplication::organizationName and
+     * QCoreApplication::applicationName namespace applied
+     * so, the following is a per application setting (user and system wide)
+     * with preference to the user setting
+     */
+    const QString key = "qtkeychainCompatNamingScheme";
+    {
+        QSettings settings;
+        if (settings.value(key, false).toBool())
+            return true;
+    }
+    {
+        QSettings settings(QSettings::Scope::SystemScope);
+        if (settings.value(key, false).toBool())
+            return true;
+    }
+    return false;
+#endif
+}
+
+static QString targetName(const QString& service, const QString& key) {
+    if (useCompatNamingScheme())
+        return key;
+
     if (key.isEmpty())
         return service;
     if (service.isEmpty())
         return key;
     return key + '@' + service;
-#endif
 }
 
 QString formatWinError(ulong errorCode)

--- a/qtkeychain/keychain_win.cpp
+++ b/qtkeychain/keychain_win.cpp
@@ -29,6 +29,31 @@ constexpr quint64 MAX_ATTRIBUTE_COUNT = 64;
 constexpr qsizetype MAX_BLOB_SIZE =
         CRED_MAX_CREDENTIAL_BLOB_SIZE + MAX_ATTRIBUTE_SIZE * MAX_ATTRIBUTE_COUNT;
 
+static bool tryCompatNamingScheme() {
+#if defined(USE_COMPAT_NAMING_SCHEME)
+	return false;
+#else
+    /* QSettings by default are instanciated with calling process
+     * QCoreApplication::organizationName and
+     * QCoreApplication::applicationName namespace applied
+     * so, the following is a per application setting (user and system wide)
+     * with preference to the user setting
+     */
+    const QString key = "qtkeychainFallbackToCompatNamingScheme";
+    {
+        QSettings settings;
+        if (settings.value(key, false).toBool())
+            return true;
+    }
+    {
+        QSettings settings(QSettings::Scope::SystemScope);
+        if (settings.value(key, false).toBool())
+            return true;
+    }
+    return false;
+#endif
+}
+
 static bool useCompatNamingScheme() {
 #if defined(USE_COMPAT_NAMING_SCHEME)
 	return true;
@@ -125,6 +150,19 @@ struct CredentialDeleter
     PCREDENTIALW m_cred;
 };
 
+static Error credRead(const QString& target, PCREDENTIALW &cred) {
+    if (!CredReadW(reinterpret_cast<const wchar_t *>(target.utf16()), CRED_TYPE_GENERIC, 0, &cred)) {
+        Error err;
+        switch (GetLastError()) {
+        case ERROR_NOT_FOUND:
+            return EntryNotFound;
+        default:
+            return OtherError;
+        }
+    }
+    return NoError;
+}
+
 /***
  * The credentials store has a limit of CRED_MAX_CREDENTIAL_BLOB_SIZE (5* 512)
  * As this might not be enough in some scenarios, for bigger payloads we use CryptProtectData which
@@ -141,7 +179,11 @@ void ReadPasswordJobPrivate::scheduledStart()
     CredentialDeleter deleter(cred);
 
     const auto& target = targetName(service, key);
-    if (!CredReadW(reinterpret_cast<const wchar_t *>(target.utf16()), CRED_TYPE_GENERIC, 0, &cred)) {
+    auto err = credRead(target, cred);
+    if ((err == EntryNotFound) && !useCompatNamingScheme() && tryCompatNamingScheme()) {
+        err = credRead(key, cred);
+    }
+    if (err != NoError) {
         Error err;
         QString msg;
         switch (GetLastError()) {

--- a/qtkeychain/keychain_win.cpp
+++ b/qtkeychain/keychain_win.cpp
@@ -29,6 +29,19 @@ constexpr quint64 MAX_ATTRIBUTE_COUNT = 64;
 constexpr qsizetype MAX_BLOB_SIZE =
         CRED_MAX_CREDENTIAL_BLOB_SIZE + MAX_ATTRIBUTE_SIZE * MAX_ATTRIBUTE_COUNT;
 
+static QString targetName(const QString& service, const QString& key) {
+#if defined(USE_COMPAT_NAMING_SCHEME)
+    Q_UNUSED(service)
+    return key;
+#else
+    if (key.isEmpty())
+        return service;
+    if (service.isEmpty())
+        return key;
+    return key + '@' + service;
+#endif
+}
+
 QString formatWinError(ulong errorCode)
 {
     return QStringLiteral("WindowsError: %1: %2")
@@ -104,7 +117,8 @@ void ReadPasswordJobPrivate::scheduledStart()
     PCREDENTIALW cred = {};
     CredentialDeleter deleter(cred);
 
-    if (!CredReadW(reinterpret_cast<const wchar_t *>(key.utf16()), CRED_TYPE_GENERIC, 0, &cred)) {
+    const auto& target = targetName(service, key);
+    if (!CredReadW(reinterpret_cast<const wchar_t *>(target.utf16()), CRED_TYPE_GENERIC, 0, &cred)) {
         Error err;
         QString msg;
         switch (GetLastError()) {
@@ -147,10 +161,11 @@ void ReadPasswordJobPrivate::scheduledStart()
 
 void WritePasswordJobPrivate::scheduledStart()
 {
+    const auto& target = targetName(service, key);
     CREDENTIALW cred = {};
     cred.Comment = const_cast<wchar_t *>(PRODUCT_NAME.data());
     cred.Type = CRED_TYPE_GENERIC;
-    cred.TargetName = const_cast<wchar_t *>(reinterpret_cast<const wchar_t *>(key.utf16()));
+    cred.TargetName = const_cast<wchar_t *>(reinterpret_cast<const wchar_t *>(target.utf16()));
     cred.Persist = CRED_PERSIST_ENTERPRISE;
 
     QByteArray buffer;
@@ -212,7 +227,8 @@ void WritePasswordJobPrivate::scheduledStart()
     // Found empirically on Win10 1803 build 17134.523.
     if (err == RPC_S_INVALID_BOUND) {
         const QString::size_type maxTargetName = CRED_MAX_GENERIC_TARGET_NAME_LENGTH;
-        if (key.size() > maxTargetName) {
+        const auto& target = targetName(service, key);
+        if (target.size() > maxTargetName) {
             q->emitFinishedWithError(
                     OtherError, tr("Credential key exceeds maximum size of %1").arg(maxTargetName));
             return;
@@ -225,7 +241,8 @@ void WritePasswordJobPrivate::scheduledStart()
 
 void DeletePasswordJobPrivate::scheduledStart()
 {
-    if (!CredDeleteW(reinterpret_cast<const wchar_t *>(key.utf16()), CRED_TYPE_GENERIC, 0)) {
+    const auto& target = targetName(service, key);
+    if (!CredDeleteW(reinterpret_cast<const wchar_t *>(target.utf16()), CRED_TYPE_GENERIC, 0)) {
         Error err;
         QString msg;
         switch (GetLastError()) {
@@ -248,7 +265,7 @@ void DeletePasswordJobPrivate::scheduledStart()
 void ReadPasswordJobPrivate::scheduledStart()
 {
     PlainTextStore plainTextStore(q->service(), q->settings());
-    QByteArray encrypted = plainTextStore.readData(key);
+    QByteArray encrypted = plainTextStore.readData(targetName(service, key));
     if (plainTextStore.error() != NoError) {
         q->emitFinishedWithError(plainTextStore.error(), plainTextStore.errorString());
         return;
@@ -272,7 +289,7 @@ void WritePasswordJobPrivate::scheduledStart()
     }
 
     PlainTextStore plainTextStore(q->service(), q->settings());
-    plainTextStore.write(key, result.first, Binary);
+    plainTextStore.write(targetName(service, key), result.first, Binary);
     if (plainTextStore.error() != NoError) {
         q->emitFinishedWithError(plainTextStore.error(), plainTextStore.errorString());
         return;
@@ -284,7 +301,7 @@ void WritePasswordJobPrivate::scheduledStart()
 void DeletePasswordJobPrivate::scheduledStart()
 {
     PlainTextStore plainTextStore(q->service(), q->settings());
-    plainTextStore.remove(key);
+    plainTextStore.remove(targetName(service, key));
     if (plainTextStore.error() != NoError) {
         q->emitFinishedWithError(plainTextStore.error(), plainTextStore.errorString());
     } else {


### PR DESCRIPTION
NOTE: Breaking change, the `service` was ignored up until now. so all existing applications that stored secrets with a previous version will not be able to find the stored credentials.

Just like #276 , but this actually resolves the issue.
Before a unique `key` was required, now only the `key@service` needs to be unique

This is required because the windows `API` identifies a credential only by `TargetName` which is neither `key` nor `service` but a combination of both.

to keep a way of compatibility the build option `USE_COMPAT_NAMING_SCHEME` has been introduced.

@frankosterfeld don't know if required (windows applications will most likely bundle this themselves) but I could add a `QSettings` to check for that as well.