### PR TITLE
Use default DBus timeout for KWallet check

### DIFF
--- a/qtkeychain/keychain_unix.cpp
+++ b/qtkeychain/keychain_unix.cpp
@@ -103,7 +103,6 @@ static bool isKwalletAvailable(const char *dbusIface, const char *dbusPath)
     // interface is activatable by making a call. Hence we check whether
     // a wallet can be opened.
 
-    iface.setTimeout(500);
     QDBusMessage reply = iface.call(QLatin1String("networkWallet"));
     return reply.type() == QDBusMessage::ReplyMessage;
 }


### PR DESCRIPTION
When just starting up, on a slow system, 500ms may be too little time for KWallet to respond

When this happens we fall back to libsecret, which can result in the right secrets not being available

Instead use the default Qt DBus timeout (25s)

If KWallet is not available the call will fail fast

Fixes https://github.com/frankosterfeld/qtkeychain/issues/242