### PR TITLE
Fix missing Map case in modeToString and stringToMode

### DIFF
--- a/qtkeychain/keychain.cpp
+++ b/qtkeychain/keychain.cpp
@@ -236,6 +236,8 @@ QString JobPrivate::modeToString(Mode m)
         return QLatin1String("Text");
     case Binary:
         return QLatin1String("Binary");
+    case Map:
+        return QLatin1String("Map");
     }
 
     Q_ASSERT_X(false, Q_FUNC_INFO, "Unhandled Mode value");
@@ -248,7 +250,8 @@ JobPrivate::Mode JobPrivate::stringToMode(const QString &s)
         return Text;
     if (s == QLatin1String("Binary") || s == QLatin1String("2"))
         return Binary;
-
+    if (s == QLatin1String("Map"))
+        return Map;
     qCritical("Unexpected mode string '%s'", qPrintable(s));
 
     return Text;


### PR DESCRIPTION
Mode::Map not handled in modeToString switch
The Map value was added to the Mode enum in 0.16.0 but modeToString's switch statement doesn't cover it, triggering -Wswitch on GCC. Also adds the matching branch in stringToMode for symmetry.