### PR TITLE
Don't block the GUI thread on KWallet availability probe (fixes #303)

### DIFF
--- a/qtkeychain/keychain_unix.cpp
+++ b/qtkeychain/keychain_unix.cpp
@@ -216,6 +216,10 @@ static void kwalletReadPasswordScheduledStartImpl(const char *service, const cha
     if (QDBusConnection::sessionBus().isConnected()) {
         priv->iface = new org::kde::KWallet(QLatin1String(service), QLatin1String(path),
                                             QDBusConnection::sessionBus(), priv);
+        // Set the long timeout before networkWallet too: kwalletd holds
+        // replies while busy (e.g. unlock dialog), and a timed-out reply
+        // here would hand an empty wallet name to open().
+        priv->iface->setTimeout(0x7FFFFFFF);
         const QDBusPendingReply<QString> reply = priv->iface->networkWallet();
         auto watcher = new QDBusPendingCallWatcher(reply, priv);
         priv->connect(watcher, &QDBusPendingCallWatcher::finished, priv,
@@ -261,6 +265,15 @@ void JobPrivate::kwalletWalletFound(QDBusPendingCallWatcher *watcher)
 {
     watcher->deleteLater();
     const QDBusPendingReply<QString> reply = *watcher;
+    // Never pass an empty wallet name to open(): kwalletd would treat it as
+    // a wallet that does not exist and show the new-wallet creation wizard.
+    if (reply.isError() || reply.value().isEmpty()) {
+        fallbackOnError(reply.isError()
+            ? reply.error()
+            : QDBusError(QDBusError::InternalError,
+                         QStringLiteral("KWallet returned no wallet name")));
+        return;
+    }
     // Don't timeout after 25s, but 24 days
     // This allows to wait for user to unlock wallet, e.g. at Plasma startup
     iface->setTimeout(0x7FFFFFFF);
@@ -486,6 +499,10 @@ static void kwalletWritePasswordScheduledStart(const char *service, const char *
     if (QDBusConnection::sessionBus().isConnected()) {
         priv->iface = new org::kde::KWallet(QLatin1String(service), QLatin1String(path),
                                             QDBusConnection::sessionBus(), priv);
+        // Set the long timeout before networkWallet too: kwalletd holds
+        // replies while busy (e.g. unlock dialog), and a timed-out reply
+        // here would hand an empty wallet name to open().
+        priv->iface->setTimeout(0x7FFFFFFF);
         const QDBusPendingReply<QString> reply = priv->iface->networkWallet();
         auto watcher = new QDBusPendingCallWatcher(reply, priv);
         priv->connect(watcher, &QDBusPendingCallWatcher::finished, priv,

--- a/qtkeychain/keychain_unix.cpp
+++ b/qtkeychain/keychain_unix.cpp
@@ -103,8 +103,15 @@ static bool isKwalletAvailable(const char *dbusIface, const char *dbusPath)
     // interface is activatable by making a call. Hence we check whether
     // a wallet can be opened.
 
+    // kwalletd holds replies while its unlock dialog is up, stalling the
+    // GUI thread. Cap the wait, and treat a timeout as "available" - the
+    // service exists, it is just busy.
+    iface.setTimeout(5000);
     QDBusMessage reply = iface.call(QLatin1String("networkWallet"));
-    return reply.type() == QDBusMessage::ReplyMessage;
+    if (reply.type() == QDBusMessage::ReplyMessage)
+        return true;
+    const QDBusError::ErrorType err = QDBusError(reply).type();
+    return err == QDBusError::NoReply || err == QDBusError::Timeout;
 }
 
 static KeyringBackend detectKeyringBackend()


### PR DESCRIPTION
Fixes #303.

## Problem

Since c7e1063 (0.16.0), `isKwalletAvailable()` does a blocking `networkWallet`
call on the default 25s timeout. That commit dropped `setTimeout(500)` to fix
#242, assuming an unavailable KWallet fails fast.

It doesn't when kwalletd is running but showing its unlock dialog: it holds
replies, so the probe neither succeeds nor fails fast, and blocks for 25s.
Detection runs inline on the first job's `scheduledStart()`, typically the GUI
thread. Any app reading a password at startup with the wallet locked freezes for
25s. For a Plasma applet, that means plasmashell freezes at every login.

## Changes

**1. Cap the probe, treat timeout as available.**

Availability isn't binary. There are three states: absent (`ServiceUnknown`, fast),
present and responsive (replies), and present but busy (times out). The third is
exactly what kwalletd is at login with a locked wallet, and both previous versions
mapped it to the wrong answer.

The probe now uses a 5s timeout and returns true on `NoReply` / `Timeout`. This
does **not** reintroduce #242: that bug was treating a timeout as *absent* and
silently caching libsecret for the process lifetime. A timeout now means present
and busy. A genuinely absent kwalletd still fails fast with `ServiceUnknown` and
is still detected as unavailable.

**2. Don't hand an empty wallet name to `open()`.**

Once detection stops stalling, jobs proceed with a locked wallet, and
`networkWallet()` in the read/write paths is still on the 25s default. It times
out, returns empty, and `open()` reads an empty name as "wallet doesn't exist" and
shows the new-wallet creation wizard. A user with an existing wallet is prompted
to create a new one; doing so leaves them with an empty wallet and no credentials.

This extends the existing 24-day timeout (already applied to `open()` for exactly
this reason) to the preceding `networkWallet()` call, and guards
`kwalletWalletFound()` against an empty name.

Bundled, because (1) alone would trade the freeze for the wizard.

Worth noting the empty name isn't only a timeout artifact. `KWalletD::networkWallet()`
returns `walletGroup.readEntry("Default Wallet", m_backend->defaultCollection(&ok))`
and never checks `ok`; `defaultCollection()` returns an empty string when
`attemptConnection()` fails. So `open("")` is reachable from a valid reply too.
This guard covers both. On a system with no wallet configured, `defaultCollection()`
returns "kdewallet", so legitimate first-run wallet creation is unaffected.

## Testing

Plasma 6, password-protected wallet, not unlocked by PAM. Login freeze gone,
wizard gone, backend still resolves to KWallet with the wallet locked. Running on
my daily driver for several days.

Isolation check: stock code with `QTKEYCHAIN_BACKEND` set (detection skipped) has
no stall, confirming the probe alone caused it.

## Notes

Async detection would remove the remaining 5s worst case and is the right
long-term shape, but it changes how every job starts, so I kept it out of scope
here.