### PR TITLE
Handle DBus error in KWallet::networkWallet

### DIFF
--- a/qtkeychain/keychain_unix.cpp
+++ b/qtkeychain/keychain_unix.cpp
@@ -258,6 +258,11 @@ void JobPrivate::kwalletWalletFound(QDBusPendingCallWatcher *watcher)
     // This allows to wait for user to unlock wallet, e.g. at Plasma startup
     iface->setTimeout(0x7FFFFFFF);
 
+    if (!reply.isValid()) {
+        q->emitFinishedWithError(OtherError, reply.error().message());
+        return;
+    }
+
     const QDBusPendingReply<int> pendingReply = iface->open(reply.value(), 0, q->service());
     auto pendingWatcher = new QDBusPendingCallWatcher(pendingReply, this);
     connect(pendingWatcher, &QDBusPendingCallWatcher::finished, this,


### PR DESCRIPTION
If the reply is an error trying to interpret the reply as a string will give the error message as string. Feeding that to openWallet() will then try to open that wallet, which makes no sense.

Instead check whether the reply is valid and error out otherwise.

See https://bugs.kde.org/show_bug.cgi?id=524718