### PR TITLE
Draft: (Hopefully) work around KDE bug 522489

### DIFF
--- a/qtkeychain/keychain_unix.cpp
+++ b/qtkeychain/keychain_unix.cpp
@@ -492,11 +492,13 @@ static void kwalletWritePasswordScheduledStart(const char *service, const char *
 
 void WritePasswordJobPrivate::scheduledStart()
 {
-    auto descr = service;
+    QString descr;
     if (service.isEmpty()) {
         descr = key;
-    } else if (!key.isEmpty()) {
-        descr = key + "@" + service;
+    } else if (key.isEmpty()) {
+        descr = service;
+    } else {
+        descr = QLatin1StringView("%1@%2").arg(key, service);
     }
 
     switch (getKeyringBackend()) {


### PR DESCRIPTION
I think it's slightly clearer like this anyway.

This is an apparent Qt bug involving a particular constellation of concatenating a QString with a COW'd copy of itself. If not, the bug is so specific that this workaround likely works anyway (but it should definitely be fixed more systematically). TODO: Try to reproduce this in Qt tests and fix it properly, failing that find whatever else the root cause is.